### PR TITLE
feat(protocol): V5 nowplayingcurrentposition alias for iOS compat

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -324,9 +324,23 @@ All maintained V4 contexts, organized by category.
 
 ### Version 4 (maintained baseline)
 
-The maintained protocol and the sole surface documented here. V4 uses object payloads,
+The maintained protocol and the primary surface documented here. V4 uses object payloads,
 pagination, string-typed player fields, and the full player / now playing / library /
-playlist surface. Every command in this document is V4.
+playlist surface. Every command in this document is V4 unless explicitly marked V5.
+
+### Version 5 (iOS compatibility)
+
+V5 is byte-identical to V4 on the wire plus **one** extra client-to-server command:
+`nowplayingcurrentposition` (see [Current Position (V5, iOS)](#current-position-v5-ios)).
+It exists purely for compatibility with the iOS client, which handshakes
+`protocol_version: 5` and, when the server also reports `>= 5`, polls current position on
+this context instead of `nowplayingposition`. The reply is identical to
+`nowplayingposition` - it is a thin alias, not a new payload.
+
+The server reports `min(client_version, 5)` in its handshake reply (the effective protocol
+is the minimum of client and server). So a V4 client is still told `4` and never sees V5
+behavior; only a client that negotiates `>= 5` unlocks the alias. The alias is rejected
+(dropped) in a V4 session.
 
 ### Legacy (V2 / V2.1 / V3)
 
@@ -882,6 +896,39 @@ Switches to a specific output device by name. Responds on the `playeroutput` con
 ```
 
 **Response:**
+```json
+{
+  "context": "nowplayingposition",
+  "data": {
+    "current": 120000,
+    "total": 245000
+  }
+}
+```
+
+---
+
+#### Current Position (V5, iOS)
+| Property | Value |
+|----------|-------|
+| Context | `nowplayingcurrentposition` |
+| Clients | iOS (V5 only) |
+| Broadcast | No |
+
+**iOS-compatibility alias, V5 only.** The iOS client polls the current position on this
+context once the server reports protocol `>= 5`. It is a query-only alias: the payload is
+ignored (it never seeks) and the reply is emitted on the `nowplayingposition` context with
+the same `{current,total}` shape. A V4 session does not accept it (the frame is dropped).
+
+**Request:**
+```json
+{
+  "context": "nowplayingcurrentposition",
+  "data": null
+}
+```
+
+**Response** (note the `nowplayingposition` context):
 ```json
 {
   "context": "nowplayingposition",

--- a/packages/mbrc-core/src/protocol/version.rs
+++ b/packages/mbrc-core/src/protocol/version.rs
@@ -11,6 +11,9 @@ use crate::wire::{WireCodec, V4_CODEC};
 pub enum ProtocolVersion {
     /// The maintained legacy V4 surface (Android + iOS 1.4.1 clients).
     V4,
+    /// The maintained legacy V5 surface: byte-identical to V4 on the wire, plus
+    /// the single iOS `nowplayingcurrentposition` c2s alias. Same codec as V4.
+    V5,
     // V6 is reserved: add the variant + a `wire::v6` formatter and map it below.
 }
 
@@ -20,14 +23,22 @@ impl ProtocolVersion {
     pub fn from_negotiated(version: u8) -> Option<Self> {
         match version {
             4 => Some(Self::V4),
+            5 => Some(Self::V5),
             _ => None,
         }
     }
 
-    /// The wire codec for this version.
+    /// The wire codec for this version. V5 shares the V4 codec: it adds one c2s
+    /// trigger, not a new wire shape.
     pub fn codec(self) -> &'static dyn WireCodec {
         match self {
-            Self::V4 => &V4_CODEC,
+            Self::V4 | Self::V5 => &V4_CODEC,
         }
+    }
+
+    /// Whether this version accepts the `nowplayingcurrentposition` c2s alias
+    /// (V5+ only; it never fires in a V4 session).
+    pub fn accepts_current_position(self) -> bool {
+        matches!(self, Self::V5)
     }
 }

--- a/packages/mbrc-core/src/server/commands/mod.rs
+++ b/packages/mbrc-core/src/server/commands/mod.rs
@@ -278,6 +278,12 @@ pub fn dispatch(ctx: &Ctx, context: &str, data: &Value) -> Option<HandlerResult>
         "nowplayingrating" => track::rating(data, ctx),
         "nowplayinglfmrating" => track::lfm_rating(data, ctx),
         "nowplayingtagchange" => track::tag_change(data, p),
+        // V5-only iOS alias. Deliberately NOT in DISPATCHED_CONTEXTS (the V4
+        // surface): it never fires in a V4 session, replies on the existing
+        // `nowplayingposition` context.
+        "nowplayingcurrentposition" if ctx.version.accepts_current_position() => {
+            track::current_position(p)
+        }
         "nowplayinglist" => nowplaying_list::list(data, ctx),
         "nowplayinglistplay" => nowplaying_list::play(data, ctx),
         "nowplayinglistremove" => nowplaying_list::remove(data, p),
@@ -321,6 +327,21 @@ mod audit {
                 "no dispatch arm for declared context {context}"
             );
         }
+    }
+
+    #[test]
+    fn current_position_alias_is_v5_only() {
+        let providers = crate::providers::NullProviders;
+        // V4 session: the alias is unknown (no arm), so dispatch returns None -
+        // it stays out of the V4 surface.
+        let v4 = Ctx::new(&providers, ProtocolVersion::V4);
+        assert!(dispatch(&v4, "nowplayingcurrentposition", &Value::Null).is_none());
+        // V5 session: the alias dispatches and replies on `nowplayingposition`.
+        let v5 = Ctx::new(&providers, ProtocolVersion::V5);
+        let out = dispatch(&v5, "nowplayingcurrentposition", &Value::Null)
+            .expect("v5 dispatches the alias")
+            .expect("handler succeeds");
+        assert_eq!(out[0].0, "nowplayingposition");
     }
 
     // ── Lenient coercion (C# `ToObject<T>()` parity) ──

--- a/packages/mbrc-core/src/server/commands/track.rs
+++ b/packages/mbrc-core/src/server/commands/track.rs
@@ -40,6 +40,14 @@ pub fn position(data: &Value, p: &dyn Providers) -> HandlerResult {
     frame_dto("nowplayingposition", &p.playback_position()?)
 }
 
+/// V5 iOS `nowplayingcurrentposition` alias: report the current `{current,total}`
+/// on the `nowplayingposition` context. Query-only - unlike `position` it never
+/// seeks, matching the C# `RequestCurrentPosition`, which ignores the payload and
+/// always reports.
+pub fn current_position(p: &dyn Providers) -> HandlerResult {
+    frame_dto("nowplayingposition", &p.playback_position()?)
+}
+
 /// Now-playing cover on request. The C# host hands over the raw MusicBee
 /// artwork; the core owns sizing and resizes it to the 600px now-playing
 /// default (matching the shipped plugin). On any resize failure we log and send
@@ -170,6 +178,17 @@ mod tests {
         assert_eq!(out[0].0, "nowplayingposition");
         assert!(m.recorded().contains(&"set_position(120000)".to_string()));
         assert!(m.recorded().contains(&"playback_position".to_string()));
+    }
+
+    #[test]
+    fn current_position_replies_on_position_context_without_seeking() {
+        // The V5 alias is query-only: it reports on `nowplayingposition` and
+        // never calls set_position, unlike the seek-or-query `position`.
+        let m = MockProviders::default();
+        let out = current_position(&m).unwrap();
+        assert_eq!(out[0].0, "nowplayingposition");
+        assert!(m.recorded().contains(&"playback_position".to_string()));
+        assert!(!m.recorded().iter().any(|c| c.starts_with("set_position")));
     }
 
     #[test]

--- a/packages/mbrc-core/src/server/session.rs
+++ b/packages/mbrc-core/src/server/session.rs
@@ -18,8 +18,11 @@ use crate::nowplaying::NowPlayingCache;
 use crate::protocol::version::ProtocolVersion;
 use crate::providers::Providers;
 
-/// Protocol version this server speaks.
-pub const SERVER_PROTOCOL: u8 = 4;
+/// Highest protocol version this server speaks. The handshake reply echoes the
+/// client's negotiated version capped at this, so a V4 client is still told 4
+/// (unchanged) while a V5 iOS client is told 5 - which is what gates it into
+/// sending `nowplayingcurrentposition`.
+pub const MAX_PROTOCOL: u8 = 5;
 /// Minimum client protocol accepted; older clients are rejected at handshake.
 pub const MIN_PROTOCOL: u8 = 4;
 /// The identity the plugin reports for the `player` context.
@@ -197,9 +200,14 @@ impl Session {
             );
             return Outcome::close();
         };
-        // The handshake only accepts versions with a formatter; default to V4
-        // defensively so a command is never dropped over a version lookup.
-        let version = ProtocolVersion::from_negotiated(negotiated).unwrap_or(ProtocolVersion::V4);
+        // Effective version = negotiated capped at what we support (mirrors the
+        // handshake reply, which reports `min(version, MAX_PROTOCOL)`). A client
+        // that negotiates >MAX is told MAX and must be dispatched as MAX too, or
+        // it would send MAX-gated commands (e.g. `nowplayingcurrentposition`)
+        // that we'd silently drop. Default to V4 defensively if the lookup ever
+        // misses, so a command is never dropped over a version lookup.
+        let version = ProtocolVersion::from_negotiated(negotiated.min(MAX_PROTOCOL))
+            .unwrap_or(ProtocolVersion::V4);
         let platform = commands::Platform::from_name(self.platform.as_deref());
         let mut ctx = commands::Ctx::new(providers, version).with_platform(platform);
         if let Some(cache) = now_playing {
@@ -270,7 +278,8 @@ impl Session {
             self.protocol_version = Some(handshake.version);
             self.no_broadcast = handshake.no_broadcast;
             self.client_id = handshake.client_id;
-            Outcome::reply(frame("protocol", json!(SERVER_PROTOCOL)))
+            let reported = handshake.version.min(MAX_PROTOCOL);
+            Outcome::reply(frame("protocol", json!(reported)))
         }
     }
 }
@@ -375,6 +384,85 @@ mod tests {
         let (c, d) = ctx(&out.replies[0]);
         assert_eq!(c, "protocol");
         assert_eq!(d, json!(4));
+    }
+
+    #[test]
+    fn protocol_v5_is_reported_back_and_unlocks_current_position() {
+        let mut s = Session::default();
+        // iOS handshakes protocol_version 5 (bare int form).
+        let out = s.handle_frame(
+            r#"{"context":"protocol","data":5}"#,
+            &NullProviders,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(s.protocol_version, Some(5));
+        let (c, d) = ctx(&out.replies[0]);
+        assert_eq!(c, "protocol");
+        assert_eq!(d, json!(5)); // echoed 5 gates iOS into sending currentposition
+
+        // The V5-only alias now dispatches and replies on `nowplayingposition`.
+        let reply = s.handle_frame(
+            r#"{"context":"nowplayingcurrentposition","data":"status"}"#,
+            &NullProviders,
+            None,
+            None,
+            None,
+        );
+        let (rc, _) = ctx(&reply.replies[0]);
+        assert_eq!(rc, "nowplayingposition");
+    }
+
+    #[test]
+    fn future_version_is_capped_to_max_and_dispatched_as_max() {
+        // A client negotiating > MAX_PROTOCOL is told MAX in the reply, so it
+        // must also be dispatched as MAX - otherwise it sends MAX-gated commands
+        // (currentposition) that we'd drop, breaking effective = min(client, max).
+        let mut s = Session::default();
+        let out = s.handle_frame(
+            r#"{"context":"protocol","data":6}"#,
+            &NullProviders,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(s.protocol_version, Some(6)); // raw negotiated is preserved
+        let (_, d) = ctx(&out.replies[0]);
+        assert_eq!(d, json!(MAX_PROTOCOL)); // but we report our cap (5)
+
+        // ...and the MAX-gated alias is honored, not dropped.
+        let reply = s.handle_frame(
+            r#"{"context":"nowplayingcurrentposition","data":"status"}"#,
+            &NullProviders,
+            None,
+            None,
+            None,
+        );
+        let (rc, _) = ctx(&reply.replies[0]);
+        assert_eq!(rc, "nowplayingposition");
+    }
+
+    #[test]
+    fn current_position_is_dropped_in_a_v4_session() {
+        let mut s = Session::default();
+        s.handle_frame(
+            r#"{"context":"protocol","data":4}"#,
+            &NullProviders,
+            None,
+            None,
+            None,
+        );
+        // A v4 session doesn't know the alias: no reply frame is produced.
+        let reply = s.handle_frame(
+            r#"{"context":"nowplayingcurrentposition","data":"status"}"#,
+            &NullProviders,
+            None,
+            None,
+            None,
+        );
+        assert!(reply.replies.is_empty());
+        assert!(!reply.close);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds the V5 `nowplayingcurrentposition` command as a thin iOS-compatibility alias, and makes the handshake report the effective (capped) protocol version so the iOS client actually reaches it.

## Why

The iOS client handshakes `protocol_version: 5` and, once the **server** also reports `>= 5`, polls the current playback position on `nowplayingcurrentposition` instead of `nowplayingposition`. The Rust core reported a flat protocol `4` and had no handler for the command, so the iOS position poll was silently dropped.

This is purely for iOS wire compatibility - it is not a new feature or payload. It mirrors the reference `old-develop` C# plugin (`RequestCurrentPosition` replies on the `nowplayingposition` context; `RequestProtocol` reports the server's version).

## Changes

- **`ProtocolVersion::V5`** - shares the V4 codec (V5 is byte-identical V4 + one c2s trigger), with an `accepts_current_position()` gate.
- **`track::current_position`** - query-only handler; replies on the existing `nowplayingposition` context with the same `{current,total}` payload. It never seeks (unlike `position`), matching the reference.
- **Dispatch** - the arm is gated on V5 and deliberately kept **out** of `DISPATCHED_CONTEXTS` (the maintained V4 surface), so it never fires in a V4 session.
- **Handshake reply** - `SERVER_PROTOCOL = 4` replaced with `MAX_PROTOCOL = 5`; the reply now echoes `min(client_version, 5)`. A V4 client is still told `4` (no Android change); a V5 iOS client is told `5`, which is what gates it into sending the alias.
- **Dispatch version cap** - the effective dispatch version is also `negotiated.min(MAX_PROTOCOL)`, so a client negotiating `> 5` (told `5`) is dispatched as `5` and its alias is honored rather than dropped - keeping "effective protocol = min(client, server)" consistent on both sides.
- **Docs** - `docs/protocol.md` documents V5 as an iOS-compat extension and the alias command (marked V5/iOS-only, reply on `nowplayingposition`).

## Tests

New coverage for the full negotiation matrix:

| Client sends | Server replies | Alias accepted? |
|---|---|---|
| 2 / 3 | rejected + close | - |
| 4 | 4 | no (dropped) |
| 5 | 5 | yes |
| 6+ | 5 (capped) | yes |

Plus a handler test that the alias is query-only (no seek). 139 core tests pass; `cargo fmt` + `clippy -D warnings` clean.

## Scope

Rust core only - no FFI surface change, no C# change, no bindgen regen. V4 wire behavior and the golden traces are unchanged (a V4 client still gets a `4` reply).