### PR TITLE
feat(settings): show recently blocked connections (#84)

### DIFF
--- a/packages/mbrc-core/src/ffi/dtos.rs
+++ b/packages/mbrc-core/src/ffi/dtos.rs
@@ -143,3 +143,21 @@ pub struct PathsParams {
 pub struct SyncDeltaParams {
     pub updated_since: i64,
 }
+
+/// A rejected inbound connection attempt, surfaced to the settings panel's
+/// "Blocked connections" view (result of the `RecentBlocked` host query). Unlike
+/// the params above this is a Rust -> C# *result*; the C# side reads a
+/// `List<BlockedConnection>`. In-memory only (see [`crate::server::blocked`]).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlockedConnection {
+    /// When the attempt was rejected, Unix epoch milliseconds (UTC). C# renders
+    /// it in local time.
+    pub unix_ms: i64,
+    /// The rejected peer's IP address (textual form).
+    pub ip: String,
+    /// The rejected peer's source port.
+    pub port: u16,
+    /// Human-readable reason (e.g. "Address not allowed", "Too many connections
+    /// from this address").
+    pub reason: String,
+}

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -190,12 +190,17 @@ pub enum CommandType {
 pub enum HostQueryType {
     /// Cache health for the settings panel (covers cached, building, ready).
     CacheStatus = 1,
+    /// Recently rejected connection attempts (address filter / caps) for the
+    /// settings panel's "Blocked connections" view. Returns a MessagePack array
+    /// of `BlockedConnection`, newest first.
+    RecentBlocked = 2,
 }
 
 impl HostQueryType {
     pub fn from_i32(value: i32) -> Option<Self> {
         match value {
             1 => Some(Self::CacheStatus),
+            2 => Some(Self::RecentBlocked),
             _ => None,
         }
     }
@@ -214,6 +219,8 @@ pub enum HostCommandType {
     /// Rebuild only the cover cache in the background. Expensive - re-fetches and
     /// re-resizes artwork per album.
     RebuildCovers = 2,
+    /// Clear the in-memory blocked-connection log (the panel's "Clear" button).
+    ClearBlockedLog = 3,
 }
 
 impl HostCommandType {
@@ -221,6 +228,7 @@ impl HostCommandType {
         match value {
             1 => Some(Self::RebuildMetadata),
             2 => Some(Self::RebuildCovers),
+            3 => Some(Self::ClearBlockedLog),
             _ => None,
         }
     }
@@ -325,7 +333,12 @@ mod tests {
     #[test]
     fn host_enums_roundtrip_and_reject_unknown() {
         assert_eq!(HostQueryType::from_i32(1), Some(HostQueryType::CacheStatus));
+        assert_eq!(
+            HostQueryType::from_i32(2),
+            Some(HostQueryType::RecentBlocked)
+        );
         assert_eq!(HostQueryType::from_i32(0), None);
+        assert_eq!(HostQueryType::from_i32(3), None);
         assert_eq!(
             HostCommandType::from_i32(1),
             Some(HostCommandType::RebuildMetadata)
@@ -334,7 +347,11 @@ mod tests {
             HostCommandType::from_i32(2),
             Some(HostCommandType::RebuildCovers)
         );
-        assert_eq!(HostCommandType::from_i32(3), None);
+        assert_eq!(
+            HostCommandType::from_i32(3),
+            Some(HostCommandType::ClearBlockedLog)
+        );
+        assert_eq!(HostCommandType::from_i32(4), None);
         // HostEventType is core -> host (no from_i32), but its contract value is
         // still pinned so the C# enum stays in sync.
         assert_eq!(HostEventType::CacheStatusChanged as i32, 1);

--- a/packages/mbrc-core/src/server/blocked.rs
+++ b/packages/mbrc-core/src/server/blocked.rs
@@ -1,0 +1,159 @@
+//! In-memory log of recently rejected connection attempts, surfaced to the
+//! settings panel so a user can see why a device was blocked (issue #84).
+//!
+//! A bounded ring buffer of the last [`MAX_ENTRIES`] rejections, newest first.
+//! Not persisted - it resets when the plugin reloads (the reject reasons are a
+//! live-debugging aid, not an audit log). Populated at the accept-loop /
+//! connection reject sites (`server::accept_loop`, `connection::run`) and read
+//! back over FFI via `HostQueryType::RecentBlocked`.
+
+use std::collections::VecDeque;
+use std::net::IpAddr;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::ffi::dtos::BlockedConnection;
+
+/// How many recent rejections to keep. Older entries are dropped.
+const MAX_ENTRIES: usize = 50;
+
+/// Why a connection attempt was rejected. The string form is what the settings
+/// panel shows; keep it user-facing (not jargon).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockReason {
+    /// Client-address filter (Range/Specific mode) did not admit the peer.
+    AddressNotAllowed,
+    /// Per-IP connection cap reached (too many sockets from one address).
+    PerIpCap,
+    /// Per-client cap reached (too many sockets from one client id).
+    PerClientCap,
+}
+
+impl BlockReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            BlockReason::AddressNotAllowed => "Address not allowed",
+            BlockReason::PerIpCap => "Too many connections from this address",
+            BlockReason::PerClientCap => "Too many connections from this client",
+        }
+    }
+}
+
+/// A thread-safe ring buffer of recent [`BlockedConnection`] entries.
+#[derive(Default)]
+pub struct BlockedLog {
+    entries: Mutex<VecDeque<BlockedConnection>>,
+}
+
+impl BlockedLog {
+    /// Record a rejected attempt. Newest is kept at the front; the oldest is
+    /// evicted once the buffer is full.
+    pub fn record(&self, ip: IpAddr, port: u16, reason: BlockReason) {
+        let entry = BlockedConnection {
+            unix_ms: now_unix_ms(),
+            ip: ip.to_string(),
+            port,
+            reason: reason.as_str().to_string(),
+        };
+        let mut q = self.lock();
+        q.push_front(entry);
+        while q.len() > MAX_ENTRIES {
+            q.pop_back();
+        }
+    }
+
+    /// A snapshot of the recent rejections, newest first.
+    pub fn recent(&self) -> Vec<BlockedConnection> {
+        self.lock().iter().cloned().collect()
+    }
+
+    /// Drop all recorded entries (the panel's "Clear" button).
+    pub fn clear(&self) {
+        self.lock().clear();
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, VecDeque<BlockedConnection>> {
+        // A poisoned lock only means a prior panic while recording; the buffer
+        // is still usable.
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Current time as Unix epoch milliseconds (UTC). Zero if the clock is before
+/// the epoch (not reachable in practice).
+fn now_unix_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn ip(last: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(192, 168, 1, last))
+    }
+
+    #[test]
+    fn records_newest_first_with_reason_text() {
+        let log = BlockedLog::default();
+        log.record(ip(10), 5000, BlockReason::AddressNotAllowed);
+        log.record(ip(11), 5001, BlockReason::PerIpCap);
+
+        let recent = log.recent();
+        assert_eq!(recent.len(), 2);
+        // Newest first.
+        assert_eq!(recent[0].ip, "192.168.1.11");
+        assert_eq!(recent[0].port, 5001);
+        assert_eq!(recent[0].reason, "Too many connections from this address");
+        assert_eq!(recent[1].ip, "192.168.1.10");
+        assert_eq!(recent[1].reason, "Address not allowed");
+        assert!(recent[0].unix_ms > 0);
+    }
+
+    #[test]
+    fn caps_at_max_entries_dropping_oldest() {
+        let log = BlockedLog::default();
+        for i in 0..(MAX_ENTRIES + 10) {
+            log.record(ip(i as u8), 6000, BlockReason::PerClientCap);
+        }
+        let recent = log.recent();
+        assert_eq!(recent.len(), MAX_ENTRIES);
+        // The most recent record (i = MAX_ENTRIES + 9) is at the front; the
+        // oldest 10 were evicted.
+        assert_eq!(
+            recent[0].ip,
+            format!("192.168.1.{}", (MAX_ENTRIES + 9) as u8)
+        );
+        assert_eq!(recent[MAX_ENTRIES - 1].ip, format!("192.168.1.{}", 10u8));
+    }
+
+    #[test]
+    fn clear_empties_the_log() {
+        let log = BlockedLog::default();
+        log.record(ip(1), 7000, BlockReason::AddressNotAllowed);
+        log.clear();
+        assert!(log.recent().is_empty());
+    }
+
+    #[test]
+    fn recent_round_trips_as_named_msgpack() {
+        // Locks the exact serialization `state::recent_blocked_bytes` uses: named
+        // maps (to_vec_named) so the C# contractless resolver reads by field name.
+        // `to_vec` (positional) would silently break the C# side.
+        let log = BlockedLog::default();
+        log.record(ip(5), 5555, BlockReason::AddressNotAllowed);
+        let bytes = rmp_serde::to_vec_named(&log.recent()).unwrap();
+        let back: Vec<BlockedConnection> = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(back.len(), 1);
+        assert_eq!(back[0].ip, "192.168.1.5");
+        assert_eq!(back[0].port, 5555);
+        assert_eq!(back[0].reason, "Address not allowed");
+        assert!(back[0].unix_ms > 0);
+    }
+}

--- a/packages/mbrc-core/src/server/connection.rs
+++ b/packages/mbrc-core/src/server/connection.rs
@@ -169,6 +169,11 @@ pub async fn run(stream: TcpStream, peer: SocketAddr, core: Arc<Core>) -> std::i
                             client_id = session.client_id.as_deref().unwrap_or("none"),
                             "rejecting connection: per-client cap reached"
                         );
+                        core.blocked.record(
+                            peer.ip(),
+                            peer.port(),
+                            crate::server::blocked::BlockReason::PerClientCap,
+                        );
                         closing = true;
                         break;
                     }

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -2,6 +2,7 @@
 //! connections and (Slice 3) fans out broadcasts. The pure handshake/dispatch
 //! logic lives in [`session`]; the per-connection IO in [`connection`].
 
+pub mod blocked;
 pub mod broadcaster;
 pub mod commands;
 pub mod connection;
@@ -339,6 +340,11 @@ async fn accept_loop(listener: TcpListener, core: Arc<Core>) {
                 // shipped plugin - so the app shows "not allowed", not a silent drop.
                 if !core.config.is_client_allowed(peer.ip()) {
                     tracing::debug!(%peer, "rejecting client: address not allowed");
+                    core.blocked.record(
+                        peer.ip(),
+                        peer.port(),
+                        blocked::BlockReason::AddressNotAllowed,
+                    );
                     tokio::spawn(reject_client(stream));
                     continue;
                 }
@@ -346,6 +352,8 @@ async fn accept_loop(listener: TcpListener, core: Arc<Core>) {
                 // so it pairs with the release after the connection ends.
                 if !core.registry.try_admit_ip(peer.ip()) {
                     tracing::debug!(%peer, "rejecting client: per-IP connection cap reached");
+                    core.blocked
+                        .record(peer.ip(), peer.port(), blocked::BlockReason::PerIpCap);
                     tokio::spawn(reject_client(stream));
                     continue;
                 }

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -16,6 +16,7 @@ use crate::ffi::types::{HostCommandType, HostQueryType, MbrcResult, Notification
 use crate::metadata_cache::MetadataCache;
 use crate::nowplaying::NowPlayingCache;
 use crate::providers::Providers;
+use crate::server::blocked::BlockedLog;
 use crate::server::broadcaster::Broadcaster;
 use crate::server::registry::ConnectionRegistry;
 use crate::server::{self, notifications, NetHandle, RebuildScope};
@@ -42,6 +43,9 @@ pub struct Core {
     /// Bounds concurrent connections (per IP + per client_id) and supersedes a
     /// stale main socket on reconnect.
     pub registry: Arc<ConnectionRegistry>,
+    /// Recent rejected connection attempts (address filter / caps), surfaced to
+    /// the settings panel. In-memory ring buffer, not persisted.
+    pub blocked: BlockedLog,
     conn_counter: AtomicU64,
     /// Wakes the background library Scanner to run a delta sooner. A library
     /// change notification (`FileAddedToLibrary`) is a debounced nudge on this,
@@ -72,6 +76,7 @@ impl Core {
             metadata_cache,
             reconciling: AtomicBool::new(false),
             registry,
+            blocked: BlockedLog::default(),
             conn_counter: AtomicU64::new(0),
             scanner_nudge: Arc::new(Notify::new()),
         }
@@ -188,6 +193,7 @@ struct CacheStatus {
 pub fn host_query(kind: HostQueryType, _params: &[u8]) -> Option<Vec<u8>> {
     match kind {
         HostQueryType::CacheStatus => cache_status_bytes(),
+        HostQueryType::RecentBlocked => recent_blocked_bytes(),
     }
 }
 
@@ -197,6 +203,7 @@ pub fn host_command(kind: HostCommandType, _params: &[u8]) -> MbrcResult {
     match kind {
         HostCommandType::RebuildMetadata => rebuild(RebuildScope::Metadata),
         HostCommandType::RebuildCovers => rebuild(RebuildScope::Covers),
+        HostCommandType::ClearBlockedLog => clear_blocked(),
     }
 }
 
@@ -215,6 +222,29 @@ fn cache_status_bytes() -> Option<Vec<u8>> {
         metadata_ready: core.metadata_cache.is_validated(),
     };
     rmp_serde::to_vec_named(&status).ok()
+}
+
+/// Serialize the recent blocked-connection entries (newest first) as MessagePack
+/// for the settings panel. `None` if the core is not initialized; an empty log
+/// serializes to an empty array (not `None`).
+fn recent_blocked_bytes() -> Option<Vec<u8>> {
+    let core = {
+        let guard = lock();
+        guard.as_ref()?.core.clone()
+    };
+    rmp_serde::to_vec_named(&core.blocked.recent()).ok()
+}
+
+/// Clear the in-memory blocked-connection log (the panel's "Clear" button).
+fn clear_blocked() -> MbrcResult {
+    let guard = lock();
+    match guard.as_ref() {
+        Some(runtime) => {
+            runtime.core.blocked.clear();
+            MbrcResult::Ok
+        }
+        None => MbrcResult::NotInitialized,
+    }
 }
 
 /// Kick a background rebuild of the requested cache (the settings panel's per-

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -406,6 +406,20 @@ mod tests {
         .unwrap();
         assert!(write_settings_bytes(&bad).is_err());
 
+        // Blocked-connection host dispatch (folded in here to avoid a second
+        // concurrent STATE test): an empty log queries to an empty array - Some,
+        // not None - and the clear command succeeds. Populating the log needs the
+        // accept loop, so the non-empty path is covered by the `blocked` unit
+        // tests; this pins the dispatch arms + the empty-not-None contract.
+        let blocked = host_query(HostQueryType::RecentBlocked, &[]).expect("recent-blocked query");
+        let entries: Vec<crate::ffi::dtos::BlockedConnection> =
+            rmp_serde::from_slice(&blocked).unwrap();
+        assert!(entries.is_empty());
+        assert_eq!(
+            host_command(HostCommandType::ClearBlockedLog, &[]),
+            MbrcResult::Ok
+        );
+
         let _ = shutdown();
     }
 }

--- a/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
@@ -275,4 +275,12 @@ namespace MusicBeePlugin.Ffi
         public long updated_since { get; set; }
     }
 
+    public class BlockedConnection
+    {
+        public long unix_ms { get; set; }
+        public string ip { get; set; }
+        public ushort port { get; set; }
+        public string reason { get; set; }
+    }
+
 }

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -107,12 +107,14 @@ namespace MusicBeePlugin.Ffi.Generated
     public enum HostQueryType
     {
         CacheStatus = 1,
+        RecentBlocked = 2,
     }
 
     public enum HostCommandType
     {
         RebuildMetadata = 1,
         RebuildCovers = 2,
+        ClearBlockedLog = 3,
     }
 
     public enum HostEventType

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -370,6 +371,17 @@ namespace MusicBeePlugin.Ffi
 
         /// <summary>Trigger a background rebuild of the cover cache.</summary>
         public bool RebuildCovers() => Command(HostCommandType.RebuildCovers);
+
+        /// <summary>
+        ///     Recent rejected connection attempts (newest first) for the settings
+        ///     panel's blocked-connections view. Never null - an empty or
+        ///     unavailable log yields an empty list.
+        /// </summary>
+        public List<BlockedConnection> ReadBlockedConnections() =>
+            Query<List<BlockedConnection>>(HostQueryType.RecentBlocked) ?? new List<BlockedConnection>();
+
+        /// <summary>Clear the core's in-memory blocked-connection log.</summary>
+        public bool ClearBlockedConnections() => Command(HostCommandType.ClearBlockedLog);
 
         /// <summary>
         ///     Apply the log level to the core's filter live (no restart needed).

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -98,6 +98,15 @@ namespace MusicBeePlugin.Host
         public bool RebuildCovers() => _bridge.RebuildCovers();
 
         /// <summary>
+        ///     Recent rejected connection attempts (newest first) for the settings
+        ///     panel's blocked-connections view. Never null.
+        /// </summary>
+        public List<BlockedConnection> ReadBlockedConnections() => _bridge.ReadBlockedConnections();
+
+        /// <summary>Clear the core's in-memory blocked-connection log.</summary>
+        public bool ClearBlockedConnections() => _bridge.ClearBlockedConnections();
+
+        /// <summary>
         ///     Core -> host push events (raised on a background thread). The
         ///     settings panel subscribes to refresh its cache line when a rebuild
         ///     starts/finishes. Forwarded from the native bridge.

--- a/packages/plugin/Settings/BlockedConnectionsDialog.cs
+++ b/packages/plugin/Settings/BlockedConnectionsDialog.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;

--- a/packages/plugin/Settings/BlockedConnectionsDialog.cs
+++ b/packages/plugin/Settings/BlockedConnectionsDialog.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Globalization;
+using System.Windows.Forms;
+using MusicBeePlugin.Ffi;
+using MusicBeePlugin.Host;
+
+namespace MusicBeePlugin.Settings
+{
+    /// <summary>
+    ///     Shows the core's recent rejected connection attempts (address filter /
+    ///     connection caps), so a user can see why a device can't connect when IP
+    ///     filtering is enabled. The list is Rust-owned and in-memory (last 50,
+    ///     newest first); this dialog only renders it and offers a Clear action.
+    ///     Auto-refreshes while open so a device blocked during troubleshooting
+    ///     appears without reopening.
+    /// </summary>
+    internal sealed class BlockedConnectionsDialog : Form
+    {
+        private const int RefreshMs = 3000;
+
+        private readonly PluginHost _host;
+        private ListView _list;
+        private Label _empty;
+        private Button _clear;
+        private Timer _timer;
+
+        public BlockedConnectionsDialog(PluginHost host)
+        {
+            _host = host;
+
+            Text = "Blocked connections";
+            FormBorderStyle = FormBorderStyle.Sizable;
+            StartPosition = FormStartPosition.CenterParent;
+            MinimizeBox = false;
+            MaximizeBox = true;
+            ShowInTaskbar = false;
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(540, 360);
+            MinimumSize = new Size(420, 260);
+
+            BuildLayout();
+            LoadEntries();
+
+            _timer = new Timer { Interval = RefreshMs };
+            _timer.Tick += (s, e) => LoadEntries();
+            _timer.Start();
+        }
+
+        protected override void OnFormClosed(FormClosedEventArgs e)
+        {
+            _timer?.Stop();
+            _timer?.Dispose();
+            base.OnFormClosed(e);
+        }
+
+        private void BuildLayout()
+        {
+            _list = new ListView
+            {
+                Dock = DockStyle.Fill,
+                View = View.Details,
+                FullRowSelect = true,
+                GridLines = true,
+                HeaderStyle = ColumnHeaderStyle.Nonclickable,
+                MultiSelect = false,
+            };
+            _list.Columns.Add("Time", 150);
+            _list.Columns.Add("IP address", 130);
+            _list.Columns.Add("Port", 60);
+            _list.Columns.Add("Reason", 180);
+
+            // Shown in place of the list when there is nothing to display.
+            _empty = new Label
+            {
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter,
+                ForeColor = SystemColors.GrayText,
+                Text = "No blocked connections recorded.",
+                Visible = false,
+            };
+
+            var listHost = new Panel { Dock = DockStyle.Fill };
+            listHost.Controls.Add(_list);
+            listHost.Controls.Add(_empty);
+
+            _clear = new Button
+            {
+                Text = "Clear",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0, 0, 8, 0),
+            };
+            _clear.Click += (s, e) => ClearLog();
+
+            var close = new Button
+            {
+                Text = "Close",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                DialogResult = DialogResult.OK,
+            };
+            close.Click += (s, e) => Close();
+
+            var buttons = new FlowLayoutPanel
+            {
+                Dock = DockStyle.Bottom,
+                FlowDirection = FlowDirection.RightToLeft,
+                WrapContents = false,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Padding = new Padding(12, 8, 12, 10),
+            };
+            // RightToLeft flow: first added sits rightmost.
+            buttons.Controls.Add(close);
+            buttons.Controls.Add(_clear);
+
+            Controls.Add(listHost);
+            Controls.Add(buttons);
+            AcceptButton = close;
+        }
+
+        /// <summary>Read the log and repaint the list, preserving scroll where possible.</summary>
+        private void LoadEntries()
+        {
+            if (IsDisposed || !IsHandleCreated) return;
+
+            List<BlockedConnection> entries;
+            try
+            {
+                entries = _host.ReadBlockedConnections();
+            }
+            catch (Exception)
+            {
+                // Core unavailable (e.g. reloading); leave the current view.
+                return;
+            }
+
+            _list.BeginUpdate();
+            try
+            {
+                _list.Items.Clear();
+                foreach (var e in entries)
+                {
+                    var when = DateTimeOffset.FromUnixTimeMilliseconds(e.unix_ms)
+                        .LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.CurrentCulture);
+                    var item = new ListViewItem(when);
+                    item.SubItems.Add(e.ip ?? string.Empty);
+                    item.SubItems.Add(e.port.ToString(CultureInfo.InvariantCulture));
+                    item.SubItems.Add(e.reason ?? string.Empty);
+                    _list.Items.Add(item);
+                }
+            }
+            finally
+            {
+                _list.EndUpdate();
+            }
+
+            var any = entries.Count > 0;
+            _list.Visible = any;
+            _empty.Visible = !any;
+            _clear.Enabled = any;
+        }
+
+        private void ClearLog()
+        {
+            _host.ClearBlockedConnections();
+            LoadEntries();
+        }
+    }
+}

--- a/packages/plugin/Settings/BlockedConnectionsDialog.cs
+++ b/packages/plugin/Settings/BlockedConnectionsDialog.cs
@@ -36,16 +36,35 @@ namespace MusicBeePlugin.Settings
             MinimizeBox = false;
             MaximizeBox = true;
             ShowInTaskbar = false;
+            ShowIcon = false; // no generic form icon in the title bar
             AutoScaleMode = AutoScaleMode.Font;
             ClientSize = new Size(540, 360);
             MinimumSize = new Size(420, 260);
 
             BuildLayout();
-            LoadEntries();
 
             _timer = new Timer { Interval = RefreshMs };
             _timer.Tick += (s, e) => LoadEntries();
             _timer.Start();
+        }
+
+        protected override void OnLoad(EventArgs e)
+        {
+            base.OnLoad(e);
+            // Populate here, not in the constructor: the window handle only exists
+            // once shown, and LoadEntries no-ops without it - doing it in the ctor
+            // left the list empty until the first timer tick.
+            LoadEntries();
+            SizeReasonColumn();
+        }
+
+        /// <summary>Stretch the last ("Reason") column to fill the list width.</summary>
+        private void SizeReasonColumn()
+        {
+            if (_list.Columns.Count < 4) return;
+            var used = _list.Columns[0].Width + _list.Columns[1].Width + _list.Columns[2].Width;
+            var fill = _list.ClientSize.Width - used - 4;
+            if (fill > 140) _list.Columns[3].Width = fill;
         }
 
         protected override void OnFormClosed(FormClosedEventArgs e)
@@ -67,9 +86,12 @@ namespace MusicBeePlugin.Settings
                 MultiSelect = false,
             };
             _list.Columns.Add("Time", 150);
-            _list.Columns.Add("IP address", 130);
-            _list.Columns.Add("Port", 60);
-            _list.Columns.Add("Reason", 180);
+            _list.Columns.Add("IP address", 120);
+            _list.Columns.Add("Port", 55);
+            // "Reason" fills the remaining width (its text is the widest column),
+            // and re-fills when the window is resized.
+            _list.Columns.Add("Reason", 200);
+            _list.Resize += (s, e) => SizeReasonColumn();
 
             // Shown in place of the list when there is nothing to display.
             _empty = new Label
@@ -85,20 +107,22 @@ namespace MusicBeePlugin.Settings
             listHost.Controls.Add(_list);
             listHost.Controls.Add(_empty);
 
+            // Equal explicit size + margin so the two buttons line up (AutoSize
+            // gave them different widths/heights and an uneven gap).
+            var buttonSize = new Size(84, 27);
             _clear = new Button
             {
                 Text = "Clear",
-                AutoSize = true,
-                AutoSizeMode = AutoSizeMode.GrowAndShrink,
-                Margin = new Padding(0, 0, 8, 0),
+                Size = buttonSize,
+                Margin = new Padding(8, 0, 0, 0),
             };
             _clear.Click += (s, e) => ClearLog();
 
             var close = new Button
             {
                 Text = "Close",
-                AutoSize = true,
-                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Size = buttonSize,
+                Margin = new Padding(8, 0, 0, 0),
                 DialogResult = DialogResult.OK,
             };
             close.Click += (s, e) => Close();

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -57,11 +57,13 @@ namespace MusicBeePlugin.Settings
         private TextBox _baseIp;
         private NumericUpDown _lastOctet;
         private TextBox _allowedAddresses;
+        private Button _blockedBtn;
         private ComboBox _searchSource;
         private ComboBox _logLevel;
         private CheckBox _firewall;
         private Label _status;
         private Label _cacheStatus;
+        private System.Windows.Forms.Timer _blockedTimer;
         private Button _rebuildMeta;
         private Button _rebuildCovers;
 
@@ -82,16 +84,26 @@ namespace MusicBeePlugin.Settings
             BuildLayout();
             LoadFromCore();
             LoadCacheStatus();
+            LoadBlockedCount();
             RunConnectionTest();
 
             // The core pushes a CacheStatusChanged event when a rebuild starts or
             // finishes; refresh the line live while this dialog is open.
             _host.CoreEvent += OnCoreEvent;
+
+            // The blocked-connections log has no push event (it is polled), so keep
+            // the count button current while this panel is open: a device blocked
+            // during troubleshooting bumps the number without reopening.
+            _blockedTimer = new System.Windows.Forms.Timer { Interval = 3000 };
+            _blockedTimer.Tick += (s, e) => LoadBlockedCount();
+            _blockedTimer.Start();
         }
 
         protected override void OnFormClosed(FormClosedEventArgs e)
         {
             _host.CoreEvent -= OnCoreEvent;
+            _blockedTimer?.Stop();
+            _blockedTimer?.Dispose();
             base.OnFormClosed(e);
         }
 
@@ -192,6 +204,20 @@ namespace MusicBeePlugin.Settings
                 Anchor = AnchorStyles.Left,
             };
 
+            // A count-only button that opens the blocked-connections view; kept
+            // out of the main layout so the panel stays uncluttered when nothing
+            // is being blocked. Disabled (greyed) while the count is zero.
+            _blockedBtn = new Button
+            {
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Anchor = AnchorStyles.Left,
+                Margin = new Padding(0),
+                Enabled = false,
+                Text = "Blocked connections (0)",
+            };
+            _blockedBtn.Click += (s, e) => ShowBlockedConnections();
+
             var layout = GroupLayout();
             AddRow(layout, "Allowed clients", _filterMode);
             AddRow(layout, "Range (base IPv4)", rangePanel);
@@ -203,6 +229,7 @@ namespace MusicBeePlugin.Settings
                 ForeColor = SystemColors.GrayText,
                 Anchor = AnchorStyles.Left,
             });
+            AddRow(layout, "Blocked", _blockedBtn);
             return WrapGroup("Access control", layout);
         }
 
@@ -485,6 +512,31 @@ namespace MusicBeePlugin.Settings
         {
             _rebuildMeta.Enabled = enabled;
             _rebuildCovers.Enabled = enabled;
+        }
+
+        /// <summary>
+        ///     Refresh the "Blocked connections (N)" button from the core's
+        ///     in-memory log. The button opens the detail view; it is greyed while
+        ///     the log is empty.
+        /// </summary>
+        private void LoadBlockedCount()
+        {
+            var count = _host.ReadBlockedConnections().Count;
+            _blockedBtn.Text = $"Blocked connections ({count})";
+            _blockedBtn.Enabled = count > 0;
+        }
+
+        /// <summary>
+        ///     Open the modal blocked-connections view, then refresh the count
+        ///     button (the view can clear the log).
+        /// </summary>
+        private void ShowBlockedConnections()
+        {
+            using (var dialog = new BlockedConnectionsDialog(_host))
+            {
+                dialog.ShowDialog(this);
+            }
+            LoadBlockedCount();
         }
 
         // Self-test: connect to the running server on loopback and round-trip a


### PR DESCRIPTION
Closes #84.

## What

When IP filtering (or a connection cap) rejects a device, users had no way to see why it couldn't connect. This adds a Rust-owned, in-memory log of recent rejections, surfaced in the settings panel.

Per the discussion, the UX is a **count button that opens a separate panel**, not an always-on table: the Access-control group gains a `Blocked connections (N)` button (greyed at 0) that opens a dedicated list view.

## Rust core

- `BlockedLog`: a bounded ring buffer (last 50, newest first) on `Core`, recorded at the three reject sites - address filter and per-IP cap (accept loop) and per-client cap (post-handshake). Each entry carries peer IP/port, a UTC `unix_ms` timestamp, and a user-facing reason. In-memory only; resets on plugin reload.
- FFI: `HostQueryType::RecentBlocked` returns the list (`to_vec_named`); `HostCommandType::ClearBlockedLog` clears it. New `BlockedConnection` DTO in `ffi/dtos.rs`, so the C# POCO is generated (no hand-written drift).

## C# plugin

- `NativeBridge`/`PluginHost` passthroughs (`ReadBlockedConnections` / `ClearBlockedConnections`).
- `BlockedConnectionsDialog`: a `ListView` (time / IP / port / reason, Reason column fills width), a **Clear** button, and a 3s refresh timer so a device blocked while it's open appears live. The count button polls on the same cadence while the settings panel is open.

## Decisions

- **Scope:** address-filter + connection caps (not supersession, which is normal reconnect behavior). Each entry has a distinct reason string.
- **Whitelist quick-action:** deferred (list + Clear only this pass).
- **Button visibility:** always present, count reflects entries.

## Tests

`BlockedLog` record / cap / clear + named-msgpack round-trip; `RecentBlocked`/`ClearBlockedLog` dispatch arms covered in the state round-trip test; host-enum round-trip updated. 143 core tests + 61 C# tests pass; generated bindings regenerated; fmt + clippy clean.

## Review notes (non-blocking, from a self-review pass)

- The count button polls the full list every 3s just for `.Count` - negligible at ≤50 entries; a count-only path could avoid it later.
- Blocked-count freshness uses a poll timer while the cache line uses a push event - a `HostEventType` at the reject sites would unify them but adds ABI surface; polling was an explicit choice.