### PR TITLE
fix(cache): refresh album covers on library changes (#91)

### DIFF
--- a/packages/mbrc-core/src/cover/store.rs
+++ b/packages/mbrc-core/src/cover/store.rs
@@ -595,4 +595,59 @@ mod tests {
 
         assert!(!orphan.exists(), "orphaned cover file should be pruned");
     }
+
+    #[test]
+    fn deleting_one_album_keeps_a_cover_another_album_still_uses() {
+        // Two albums whose artwork resizes to identical bytes share ONE
+        // content-hashed file. Removing one album (its last track deleted, so it
+        // drops out of the album list) must NOT delete that file while the other
+        // album still references it - and must delete it once nothing does. This
+        // is the deletion-safety the Scanner's nudge-path cover delta relies on.
+        let (db, dir) = temp_storage("shared-delete");
+        let store = CoverStore::new(db.clone(), &dir);
+        let art = jpeg_bytes(200, 200);
+
+        store.warm_up(&[
+            AlbumIdentity {
+                key: "alb1".into(),
+                path: "/a.mp3".into(),
+                modified: 0,
+            },
+            AlbumIdentity {
+                key: "alb2".into(),
+                path: "/b.mp3".into(),
+                modified: 0,
+            },
+        ]);
+        store.build(|_| Some(art.clone()), false);
+
+        // Same artwork -> same hash -> one shared file referenced by both albums.
+        let hash = store.hash_for("alb1").expect("alb1 cached");
+        assert_eq!(store.hash_for("alb2"), Some(hash.clone()), "shared hash");
+        assert!(store.cover_file(&hash).exists());
+
+        // Delete alb2 (gone from the album list). alb1 still holds the hash, so a
+        // re-warm + build keeps the shared file.
+        let store = CoverStore::new(db.clone(), &dir);
+        store.warm_up(&[AlbumIdentity {
+            key: "alb1".into(),
+            path: "/a.mp3".into(),
+            modified: 0,
+        }]);
+        store.build(|_| Some(art.clone()), false);
+        assert_eq!(store.hash_for("alb2"), None, "deleted album key dropped");
+        assert!(
+            store.cover_file(&hash).exists(),
+            "shared cover file must survive while another album uses it"
+        );
+
+        // Delete alb1 too: nothing references the hash now, so it is pruned.
+        let store = CoverStore::new(db, &dir);
+        store.warm_up(&[]);
+        store.build(|_| Some(art.clone()), false);
+        assert!(
+            !store.cover_file(&hash).exists(),
+            "cover file pruned once no album references it"
+        );
+    }
 }

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -316,6 +316,80 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
     core.end_reconcile();
 }
 
+/// Incremental album-cover refresh, run from the Scanner's nudge path (a
+/// `FileAddedToLibrary` / `TagsChanged` / `FileDeleted` notification). Unlike
+/// [`run_reconcile`] this does no metadata work and stays quiet: it only
+/// broadcasts `librarycovercachebuildstatus` when the cached cover set actually
+/// changed, so a nudge that touched no artwork produces no client traffic and no
+/// status-bar churn.
+///
+/// The delta is entirely `warm_up` + `build`:
+/// - `warm_up` re-maps album keys from the live `album_identifiers` and drops the
+///   covers of albums that were modified (artwork edited) or removed (last track
+///   deleted). An album key survives while any track keeps it in the library, and
+///   `prune_orphans` only deletes a content-hashed file once no key references it,
+///   so a delete never removes a cover another album still uses.
+/// - `build` refetches the dropped/new albums' artwork.
+///
+/// The caller must already hold the reconcile single-flight guard (the Scanner
+/// does), so this can't race an init/library-switch/manual rebuild.
+pub(crate) fn refresh_covers_delta(core: &Arc<Core>) {
+    use crate::cover::{cover_identifier, from_base64, store::AlbumIdentity};
+
+    let identities: Vec<AlbumIdentity> = match core.providers.album_identifiers() {
+        Ok(identifiers) => identifiers
+            .into_iter()
+            .map(|a| AlbumIdentity {
+                key: cover_identifier(&a.artist, &a.album),
+                path: a.path,
+                modified: a.modified,
+            })
+            .collect(),
+        Err(e) => {
+            tracing::warn!(error = %e, "cover delta: album enumeration failed");
+            return;
+        }
+    };
+
+    // `dropped` (covers invalidated by an edit/delete) plus `stored` (covers
+    // (re)fetched) together tell us whether the grid changed. A pure deletion
+    // drops without storing; a new album with art stores without dropping.
+    let before = core.cover_store.cached_count();
+    core.cover_store.warm_up(&identities);
+    let kept = core.cover_store.cached_count();
+    let dropped = before.saturating_sub(kept);
+
+    let providers = core.providers.clone();
+    let stats = core.cover_store.build(
+        |path| {
+            let b64 = providers.artwork_raw(path).ok()?;
+            if b64.is_empty() {
+                return None;
+            }
+            from_base64(&b64)
+        },
+        core.config.log_level.is_trace(),
+    );
+
+    let changed = dropped > 0 || stats.stored > 0;
+    tracing::debug!(
+        albums = identities.len(),
+        dropped,
+        stored = stats.stored,
+        cached = core.cover_store.cached_count(),
+        changed,
+        "cover delta complete"
+    );
+    if changed {
+        // A single `false` frame means "cover cache updated, refetch the grid" -
+        // the same signal the init/switch build sends on completion.
+        core.broadcaster.broadcast(&[notifications::frame(
+            "librarycovercachebuildstatus",
+            serde_json::json!(false),
+        )]);
+    }
+}
+
 /// RAII release of a reserved per-IP connection slot. Dropping it (normal end
 /// OR a panic unwinding the connection task) returns the slot to the registry,
 /// so a panicking connection can't slowly exhaust an IP's cap.
@@ -382,4 +456,64 @@ async fn reject_client(mut stream: tokio::net::TcpStream) {
     let frame = mbrc_wire::frame_line(&notifications::frame("notallowed", serde_json::json!("")));
     let _ = stream.write_all(frame.as_bytes()).await;
     let _ = stream.shutdown().await;
+}
+
+#[cfg(test)]
+mod cover_delta_tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::protocol::messages::AlbumIdentifier;
+    use crate::providers::MockProviders;
+    use tokio::sync::mpsc;
+
+    /// Build a `Core` on a fresh temp storage dir with a mock host that returns
+    /// `albums` for the album scan and one canned JPEG for every artwork fetch.
+    fn temp_core(name: &str, albums: Vec<AlbumIdentifier>) -> Arc<Core> {
+        let dir = std::env::temp_dir().join(format!("mbrc-cover-delta-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mock = MockProviders {
+            album_identifiers: albums,
+            artwork_raw: crate::cover::to_base64(&crate::cover::test_jpeg_bytes(300, 300)),
+            ..MockProviders::default()
+        };
+        let config = Config {
+            storage_path: dir.to_string_lossy().into_owned(),
+            ..Config::default()
+        };
+        Arc::new(Core::new(Arc::new(mock), config))
+    }
+
+    fn album(artist: &str, name: &str, path: &str, modified: i64) -> AlbumIdentifier {
+        AlbumIdentifier {
+            artist: artist.into(),
+            album: name.into(),
+            path: path.into(),
+            modified,
+        }
+    }
+
+    /// The nudge-path cover delta broadcasts `librarycovercachebuildstatus` only
+    /// when the cached cover set actually changed: once for the initial build,
+    /// then silence on a re-run that touched nothing (issue #91's requirement -
+    /// no idle-nudge spam to connected clients).
+    #[test]
+    fn broadcasts_on_change_and_stays_silent_otherwise() {
+        let core = temp_core("gate", vec![album("Artist", "Album", "/a.mp3", 0)]);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        core.broadcaster.register(1, tx);
+
+        // First pass builds the album's cover -> grid changed -> one status frame.
+        refresh_covers_delta(&core);
+        let frame = rx.try_recv().expect("a built cover must broadcast");
+        assert!(frame.contains("librarycovercachebuildstatus"), "{frame}");
+        assert!(rx.try_recv().is_err(), "exactly one frame for one change");
+
+        // Second pass: same unmodified album -> nothing dropped, nothing built.
+        refresh_covers_delta(&core);
+        assert!(
+            rx.try_recv().is_err(),
+            "an unchanged cover delta must not broadcast"
+        );
+    }
 }

--- a/packages/mbrc-core/src/server/scanner.rs
+++ b/packages/mbrc-core/src/server/scanner.rs
@@ -44,7 +44,10 @@ pub async fn run(core: Arc<Core>, shutdown: Arc<Notify>) {
             _ = core.scanner_nudge.notified() => {
                 // Debounce: let a burst of per-file nudges settle before scanning.
                 tokio::time::sleep(Duration::from_secs(DEBOUNCE_SECS)).await;
-                scan(&core).await;
+                // A nudge means the library actually changed (a file was added,
+                // its tags edited, or it was deleted), so refresh the cover cache
+                // too - the only place a runtime artwork edit reaches the grid.
+                scan(&core, true).await;
             }
             _ = interval.tick() => {
                 if core.broadcaster.client_count() > 0 {
@@ -58,7 +61,10 @@ pub async fn run(core: Arc<Core>, shutdown: Arc<Notify>) {
                         clients = core.broadcaster.client_count(),
                         "core memory sample"
                     );
-                    scan(&core).await;
+                    // Periodic safety net for metadata only; the album cover
+                    // delta rides the nudge path (an explicit change signal), so
+                    // an idle tick never does the extra album-enumeration FFI.
+                    scan(&core, false).await;
                 }
             }
         }
@@ -66,16 +72,29 @@ pub async fn run(core: Arc<Core>, shutdown: Arc<Notify>) {
 }
 
 /// Run one delta pass on a blocking worker, under the reconcile single-flight
-/// guard (so it never races an init/library-switch rebuild).
-async fn scan(core: &Arc<Core>) {
+/// guard (so it never races an init/library-switch rebuild). When `covers` is
+/// set (the nudge path), the album cover cache is delta-refreshed too.
+async fn scan(core: &Arc<Core>, covers: bool) {
+    use crate::ffi::types::HostEventType;
+
     let core = core.clone();
     let _ = tokio::task::spawn_blocking(move || {
         if !core.try_begin_reconcile() {
             tracing::debug!("scanner: reconcile in progress; skipping delta");
             return;
         }
+        // Tell the settings panel a scan is running (its cache-status line reads
+        // `is_reconciling`), matching what a manual rebuild emits. Paired with the
+        // finish event below so the line clears once the delta completes.
+        core.providers
+            .emit_event(HostEventType::CacheStatusChanged, &[]);
         commands::library::refresh_library_delta(&core.metadata_cache, core.providers.as_ref());
+        if covers {
+            super::refresh_covers_delta(&core);
+        }
         core.end_reconcile();
+        core.providers
+            .emit_event(HostEventType::CacheStatusChanged, &[]);
     })
     .await;
 }

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -57,7 +57,13 @@ namespace MusicBeePlugin
             _about.Revision = Convert.ToInt16(version.Build);
             _about.MinInterfaceVersion = MinInterfaceVersion;
             _about.MinApiRevision = MinApiRevision;
-            _about.ReceiveNotifications = ReceiveNotificationFlags.PlayerEvents;
+            // PlayerEvents drives the now-playing/transport broadcasts; TagEvents
+            // delivers the library-change notifications the Scanner reacts to
+            // (FileAddedToLibrary, TagsChanged, FileDeleted, LibrarySwitched) so a
+            // tag/artwork edit refreshes the metadata + cover caches without a
+            // restart. Unhandled types are ignored in ReceiveNotification.
+            _about.ReceiveNotifications =
+                ReceiveNotificationFlags.PlayerEvents | ReceiveNotificationFlags.TagEvents;
             // Non-zero height tells MusicBee this plugin has a preferences panel;
             // MusicBee then calls Configure(panelHandle) to populate it. The panel
             // now holds only a Configure button, so it needs little room.
@@ -230,6 +236,12 @@ namespace MusicBeePlugin
                     coreType = FfiGen.NotificationType.NowPlayingListChanged;
                     break;
                 case NotificationType.FileAddedToLibrary:
+                // Tag edits (artwork included) and deletions change the library
+                // exactly like an add from the core's view: nudge the Scanner to
+                // run a metadata + cover delta. Mapped to the same core
+                // notification so no extra FFI variant is needed.
+                case NotificationType.TagsChanged:
+                case NotificationType.FileDeleted:
                     coreType = FfiGen.NotificationType.FileAddedToLibrary;
                     break;
                 case NotificationType.LibrarySwitched:


### PR DESCRIPTION
## Problem

Fixes #91. Album covers only refreshed on restart or library-switch. Editing a track's tags or embedded artwork in MusicBee never reached the cover cache at runtime, so the library cover grid stayed stale until MusicBee was restarted.

The issue as filed targeted the old C# cover stack (`CoverService`/`CoverCache`/`NotificationHandler`), all deleted in the Rust rewrite. This re-implements the fix against the current Rust core.

## Root cause

The album cover cache had **no runtime invalidation path**. `warm_up`+`build` (which already contain the `modified >= last_check` delta logic) only ran on init, library-switch, or the manual settings button. The background Scanner refreshed track metadata but never touched covers. Separately, `TagsChanged` and `FileDeleted` were dropped at the C# notification switch.

## Change

- **Forward `TagsChanged` (11) + `FileDeleted` (26)** from C#, mapped to the existing `FileAddedToLibrary` nudge. Subscribe to `TagEvents` so MusicBee delivers them.
- **`refresh_covers_delta`** on the Scanner nudge path: re-enumerate albums, `warm_up` drops changed/removed albums, `build` refetches. Broadcasts `librarycovercachebuildstatus` **only when the cached set actually changed** (built or removed), so an idle nudge produces no client traffic.
- **Nudge-path only** for covers; the 60s periodic tick stays metadata-only (no per-tick album-enumeration FFI).
- **`CacheStatusChanged`** emitted at scan start/end so the settings panel reflects a running scan, same as a manual rebuild.

Bursts coalesce: the nudge is a single-permit `Notify`, debounced 2s, under the reconcile single-flight guard, and the delta is idempotent (reads current library state) - so a bulk import/edit collapses to 1-2 passes refetching only genuinely-changed covers.

## Deletion safety

Safe by construction, no special-casing: covers are keyed per album and files are content-addressed. A cover file is pruned only once **no** album references its hash, so a shared cover survives while another album still uses it; an album key only disappears when its last track leaves the library.

## Tests

- `broadcasts_on_change_and_stays_silent_otherwise` - cover delta broadcasts on a real change, stays silent on a no-op nudge.
- `deleting_one_album_keeps_a_cover_another_album_still_uses` - shared content-hash file survives one album's deletion, pruned only when unreferenced.

Rust 145 tests + C# 61 tests pass; fmt + clippy clean.