### PR TITLE
fix(#123): storage-dir robustness + guard plugin crash paths

### DIFF
--- a/packages/mbrc-core/src/store/mod.rs
+++ b/packages/mbrc-core/src/store/mod.rs
@@ -84,6 +84,14 @@ impl Db {
         if storage_path.is_empty() {
             return Db(None);
         }
+        // Ensure the storage directory exists before redb tries to create the
+        // file in it. MusicBee's persistent-storage path normally exists, but on
+        // a portable install pointed at a not-yet-created path this turns a
+        // silent "persistence disabled" into a working cache. Best-effort: a
+        // failure here just falls through to the graceful degrade below.
+        if let Err(e) = std::fs::create_dir_all(storage_path) {
+            tracing::warn!(error = %e, path = storage_path, "could not create storage dir");
+        }
         let path = Path::new(storage_path).join("mbrc.redb");
         match Self::create_db(&path) {
             Ok(db) => Db(Some(Arc::new(db))),
@@ -271,6 +279,20 @@ mod tests {
             Ok(t.get("k")?.map(|g| g.value().to_string()))
         });
         assert_eq!(got, Some(Some("hash".to_string())));
+    }
+
+    #[test]
+    fn open_creates_missing_storage_dir() {
+        // A storage path whose (nested) directory does not exist yet must be
+        // created, not silently degrade to persistence-disabled - the robustness
+        // side of issue #123 (portable install, missing cache dir).
+        let base = temp_dir("missing-parent");
+        let nested = base.join("deep").join("not-there");
+        assert!(!nested.exists());
+
+        let db = Db::open(nested.to_str().unwrap());
+        assert!(db.is_active(), "persistence should be enabled");
+        assert!(nested.join("mbrc.redb").exists());
     }
 
     #[test]

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -525,7 +525,16 @@ namespace MusicBeePlugin.Ffi
 
         private void OnFreeBuffer(IntPtr buf)
         {
-            if (buf != IntPtr.Zero) Marshal.FreeHGlobal(buf);
+            // Called from the core across the FFI boundary; never throw back into
+            // native code (a managed exception unwinding into Rust is UB).
+            try
+            {
+                if (buf != IntPtr.Zero) Marshal.FreeHGlobal(buf);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "free buffer callback threw");
+            }
         }
 
         // Core -> host push. Called from a core/background thread; just re-raise

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -40,46 +40,57 @@ namespace MusicBeePlugin
         /// <returns></returns>
         public PluginInfo Initialise(IntPtr apiInterfacePtr)
         {
-            _api = new MusicBeeApiInterface();
-            _api.Initialise(apiInterfacePtr);
+            // MusicBee calls this directly; an exception escaping here would take
+            // the host down. The whole body is guarded so a failure leaves the
+            // plugin degraded (remote off) but MusicBee running, returning the
+            // (field-initialized) _about either way.
+            try
+            {
+                _api = new MusicBeeApiInterface();
+                _api.Initialise(apiInterfacePtr);
 
-            var version = Assembly.GetExecutingAssembly().GetName().Version;
-            _version = version.ToString();
+                var version = Assembly.GetExecutingAssembly().GetName().Version;
+                _version = version.ToString();
 
-            _about.PluginInfoVersion = PluginInfoVersion;
-            _about.Name = "MusicBee Remote: Plugin";
-            _about.Description = "Remote Control for server to be used with android application.";
-            _about.Author = "Konstantinos Paparas (aka Kelsos)";
-            _about.TargetApplication = "MusicBee Remote";
-            _about.Type = PluginType.General;
-            _about.VersionMajor = Convert.ToInt16(version.Major);
-            _about.VersionMinor = Convert.ToInt16(version.Minor);
-            _about.Revision = Convert.ToInt16(version.Build);
-            _about.MinInterfaceVersion = MinInterfaceVersion;
-            _about.MinApiRevision = MinApiRevision;
-            // PlayerEvents drives the now-playing/transport broadcasts; TagEvents
-            // delivers the library-change notifications the Scanner reacts to
-            // (FileAddedToLibrary, TagsChanged, FileDeleted, LibrarySwitched) so a
-            // tag/artwork edit refreshes the metadata + cover caches without a
-            // restart. Unhandled types are ignored in ReceiveNotification.
-            _about.ReceiveNotifications =
-                ReceiveNotificationFlags.PlayerEvents | ReceiveNotificationFlags.TagEvents;
-            // Non-zero height tells MusicBee this plugin has a preferences panel;
-            // MusicBee then calls Configure(panelHandle) to populate it. The panel
-            // now holds only a Configure button, so it needs little room.
-            _about.ConfigurationPanelHeight = 120;
+                _about.PluginInfoVersion = PluginInfoVersion;
+                _about.Name = "MusicBee Remote: Plugin";
+                _about.Description = "Remote Control for server to be used with android application.";
+                _about.Author = "Konstantinos Paparas (aka Kelsos)";
+                _about.TargetApplication = "MusicBee Remote";
+                _about.Type = PluginType.General;
+                _about.VersionMajor = Convert.ToInt16(version.Major);
+                _about.VersionMinor = Convert.ToInt16(version.Minor);
+                _about.Revision = Convert.ToInt16(version.Build);
+                _about.MinInterfaceVersion = MinInterfaceVersion;
+                _about.MinApiRevision = MinApiRevision;
+                // PlayerEvents drives the now-playing/transport broadcasts; TagEvents
+                // delivers the library-change notifications the Scanner reacts to
+                // (FileAddedToLibrary, TagsChanged, FileDeleted, LibrarySwitched) so a
+                // tag/artwork edit refreshes the metadata + cover caches without a
+                // restart. Unhandled types are ignored in ReceiveNotification.
+                _about.ReceiveNotifications =
+                    ReceiveNotificationFlags.PlayerEvents | ReceiveNotificationFlags.TagEvents;
+                // Non-zero height tells MusicBee this plugin has a preferences panel;
+                // MusicBee then calls Configure(panelHandle) to populate it. The panel
+                // now holds only a Configure button, so it needs little room.
+                _about.ConfigurationPanelHeight = 120;
 
-            if (_api.ApiRevision < MinApiRevision)
-                return _about;
+                if (_api.ApiRevision < MinApiRevision)
+                    return _about;
 
-            InitializeHost(version);
+                InitializeHost(version);
 
-            // A Tools menu entry opens the same settings dialog as the Configure
-            // button, matching the classic plugin's layout.
-            _api.MB_AddMenuItem(
-                "mnuTools/MusicBee Remote",
-                "MusicBee Remote: open settings",
-                (sender, args) => OpenSettingsDialog());
+                // A Tools menu entry opens the same settings dialog as the Configure
+                // button, matching the classic plugin's layout.
+                _api.MB_AddMenuItem(
+                    "mnuTools/MusicBee Remote",
+                    "MusicBee Remote: open settings",
+                    (sender, args) => OpenSettingsDialog());
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("FATAL: Plugin Initialise failed", ex);
+            }
 
             return _about;
         }
@@ -93,8 +104,18 @@ namespace MusicBeePlugin
             if (_host == null)
                 return;
 
-            using (var dialog = new SettingsDialog(_host, _version))
-                dialog.ShowDialog();
+            // Invoked by MusicBee (Tools-menu callback) and by the Configure
+            // button; guard so a dialog-construction failure never escapes to the
+            // host.
+            try
+            {
+                using (var dialog = new SettingsDialog(_host, _version))
+                    dialog.ShowDialog();
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Settings dialog failed", ex);
+            }
         }
 
         /// <summary>
@@ -114,23 +135,33 @@ namespace MusicBeePlugin
             {
                 // Log the error to a fallback location and ensure the plugin
                 // never crashes MusicBee.
-                try
-                {
-                    var fallbackPath = Path.Combine(
-                        _api.Setting_GetPersistentStoragePath(),
-                        "mb_remote",
-                        "initialization_error.log");
-                    Directory.CreateDirectory(Path.GetDirectoryName(fallbackPath));
-                    File.AppendAllText(fallbackPath,
-                        $"[{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}] FATAL: Plugin initialization failed: {ex}\n");
-                }
-                catch
-                {
-                    // If logging fails, continue silently to prevent MusicBee crash
-                }
+                LogToFallback("FATAL: Plugin initialization failed", ex);
 
                 // Ensure _host is null so other methods handle it gracefully.
                 _host = null;
+            }
+        }
+
+        /// <summary>
+        ///     Best-effort error log to a fallback file, used by the MusicBee-facing
+        ///     entry points so a failure is recorded but never propagates into the
+        ///     host. Swallows its own errors (including a missing/failed API).
+        /// </summary>
+        private void LogToFallback(string context, Exception ex)
+        {
+            try
+            {
+                var fallbackPath = Path.Combine(
+                    _api.Setting_GetPersistentStoragePath(),
+                    "mb_remote",
+                    "initialization_error.log");
+                Directory.CreateDirectory(Path.GetDirectoryName(fallbackPath));
+                File.AppendAllText(fallbackPath,
+                    $"[{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}] {context}: {ex}\n");
+            }
+            catch
+            {
+                // If logging fails, continue silently to prevent MusicBee crash.
             }
         }
 
@@ -149,13 +180,23 @@ namespace MusicBeePlugin
             if (_host == null || panelHandle == IntPtr.Zero)
                 return false;
 
-            var panel = Control.FromHandle(panelHandle);
-            if (panel == null)
-                return false;
+            // MusicBee calls this directly; guard so a panel-construction failure
+            // returns false instead of propagating into the host.
+            try
+            {
+                var panel = Control.FromHandle(panelHandle);
+                if (panel == null)
+                    return false;
 
-            _configPanel = new ConfigurationPanel(_host, _version);
-            _configPanel.AttachTo(panel);
-            return true;
+                _configPanel = new ConfigurationPanel(_host, _version);
+                _configPanel.AttachTo(panel);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Configure panel failed", ex);
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Investigates #123 and hardens the surrounding conditions.

## #123 itself is no longer valid

The reported crash was the **old** C# `CoverCache.PersistCache()` throwing `DirectoryNotFoundException` writing `M:\...\cache\state.json` on a portable install. That code path is deleted - cover state now lives in `mbrc.redb` at the storage-path **root** (which MusicBee guarantees exists), and `Db::open` degrades gracefully (logs, disables persistence) rather than throwing. So it can't crash MusicBee anymore.

## What this PR adds

**1. Storage-dir robustness (`store/mod.rs`).**
`Db::open` now `create_dir_all(storage_path)` before creating the redb file, so a portable install pointed at a not-yet-created path gets a **working** cache instead of silently disabling persistence. Best-effort; a failure still falls through to the existing graceful degrade. Test: `open_creates_missing_storage_dir`.

**2. Exception-safety audit + fixes (the "no path crashes MusicBee" check).**
Audited the two crash boundaries - MusicBee→plugin entry points, and Rust→C# FFI callbacks. Found and guarded four unguarded paths:

- **`NativeBridge.OnFreeBuffer`** - the only Rust-invokable FFI callback without a guard. A `Marshal.FreeHGlobal` throw would unwind into native Rust (undefined behavior). Now caught, matching the other three callbacks (`OnQueryData`/`OnExecuteCommand`/`OnCoreEvent`, all already guarded).
- **`Plugin.Configure`**, **`Plugin.OpenSettingsDialog`** (Tools-menu callback), **`Plugin.Initialise`** - MusicBee-invoked entry points whose bodies (panel/dialog construction, version parsing, `MB_AddMenuItem`) sat outside any try/catch. Now guarded; failures log to the fallback file and degrade instead of propagating into the host.
- Extracted the inline fallback-log pattern from `InitializeHost` into a shared `LogToFallback` helper.

### Audit result (everything else was already safe)
- `ReceiveNotification`, `Close`, `Uninstall`, `SaveSettings` - guarded (directly or via fully-wrapped downstream calls).
- FFI callbacks `OnQueryData` / `OnExecuteCommand` / `OnCoreEvent` - already catch-all wrapped.
- Background work: only a `ThreadPool` connection self-test and a WinForms UI `Timer`, both guarded / UI-thread. No `new Thread`, `Task.Run`, `System.Timers.Timer`, or `async void` anywhere in the plugin.
- WinForms settings handlers run on the dialog's UI thread (user-opened), so at worst a `ThreadException`, not a process crash.

## Verification
Rust 146 tests + C# 61 tests pass; fmt + clippy + dotnet format clean; both DLLs build.