### PR TITLE
feat(settings): show reachable listening addresses in Configure panel

### DIFF
--- a/packages/mbrc-core/src/discovery.rs
+++ b/packages/mbrc-core/src/discovery.rs
@@ -153,7 +153,11 @@ fn same_subnet(a: Ipv4Addr, b: Ipv4Addr, mask: Ipv4Addr) -> bool {
 /// a client can never reach: loopback, unspecified, and `169.254.x`
 /// link-local (APIPA). Virtual-adapter subnets are left in - the subnet match
 /// against the client sorts those out; they only surface as a fallback.
-fn usable_ipv4_ifaces() -> Vec<(Ipv4Addr, Ipv4Addr)> {
+///
+/// Also the source for the settings panel's "reachable at" list (via
+/// `HostQueryType::ListeningAddresses`): the same set the discovery responder
+/// would advertise is exactly what the user should point a client at.
+pub(crate) fn usable_ipv4_ifaces() -> Vec<(Ipv4Addr, Ipv4Addr)> {
     if_addrs::get_if_addrs()
         .unwrap_or_default()
         .into_iter()

--- a/packages/mbrc-core/src/ffi/dtos.rs
+++ b/packages/mbrc-core/src/ffi/dtos.rs
@@ -161,3 +161,17 @@ pub struct BlockedConnection {
     /// from this address").
     pub reason: String,
 }
+
+/// The addresses a client can reach the server on, surfaced to the settings
+/// panel (result of the `ListeningAddresses` host query) so the user knows what
+/// to point the phone client at - the way the shipped C# 1.4.1 panel listed the
+/// candidate IPs. A Rust -> C# *result*; the C# side reads a `ListeningInfo`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListeningInfo {
+    /// The TCP port the command server is bound to (the configured port; the
+    /// listener binds `0.0.0.0`, so every address below is reachable on it).
+    pub port: u16,
+    /// Candidate interface IPv4 addresses (textual), loopback/link-local
+    /// dropped. Empty when the host has no reachable non-loopback interface.
+    pub addresses: Vec<String>,
+}

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -194,6 +194,10 @@ pub enum HostQueryType {
     /// settings panel's "Blocked connections" view. Returns a MessagePack array
     /// of `BlockedConnection`, newest first.
     RecentBlocked = 2,
+    /// The addresses a client can reach the server on: candidate interface IPv4s
+    /// plus the bound port. The settings panel shows these so the user knows what
+    /// to point the phone at. Returns a MessagePack `ListeningInfo`.
+    ListeningAddresses = 3,
 }
 
 impl HostQueryType {
@@ -201,6 +205,7 @@ impl HostQueryType {
         match value {
             1 => Some(Self::CacheStatus),
             2 => Some(Self::RecentBlocked),
+            3 => Some(Self::ListeningAddresses),
             _ => None,
         }
     }
@@ -337,8 +342,12 @@ mod tests {
             HostQueryType::from_i32(2),
             Some(HostQueryType::RecentBlocked)
         );
+        assert_eq!(
+            HostQueryType::from_i32(3),
+            Some(HostQueryType::ListeningAddresses)
+        );
         assert_eq!(HostQueryType::from_i32(0), None);
-        assert_eq!(HostQueryType::from_i32(3), None);
+        assert_eq!(HostQueryType::from_i32(4), None);
         assert_eq!(
             HostCommandType::from_i32(1),
             Some(HostCommandType::RebuildMetadata)

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -194,6 +194,7 @@ pub fn host_query(kind: HostQueryType, _params: &[u8]) -> Option<Vec<u8>> {
     match kind {
         HostQueryType::CacheStatus => cache_status_bytes(),
         HostQueryType::RecentBlocked => recent_blocked_bytes(),
+        HostQueryType::ListeningAddresses => listening_info_bytes(),
     }
 }
 
@@ -233,6 +234,22 @@ fn recent_blocked_bytes() -> Option<Vec<u8>> {
         guard.as_ref()?.core.clone()
     };
     rmp_serde::to_vec_named(&core.blocked.recent()).ok()
+}
+
+/// Serialize the addresses a client can reach the server on (candidate interface
+/// IPv4s + the bound port) as MessagePack for the settings panel. `None` if the
+/// core is not initialized; an interface-less host yields an empty address list.
+fn listening_info_bytes() -> Option<Vec<u8>> {
+    let port = {
+        let guard = lock();
+        guard.as_ref()?.core.config.port
+    };
+    let addresses = crate::discovery::usable_ipv4_ifaces()
+        .into_iter()
+        .map(|(ip, _mask)| ip.to_string())
+        .collect();
+    let info = crate::ffi::dtos::ListeningInfo { port, addresses };
+    rmp_serde::to_vec_named(&info).ok()
 }
 
 /// Clear the in-memory blocked-connection log (the panel's "Clear" button).
@@ -419,6 +436,15 @@ mod tests {
             host_command(HostCommandType::ClearBlockedLog, &[]),
             MbrcResult::Ok
         );
+
+        // Listening-addresses host dispatch: reports the in-memory bound port
+        // (4321, not the 5555 just written - a write doesn't hot-reload). The
+        // address list is interface-dependent (empty on a loopback-only runner),
+        // so only the port is pinned here.
+        let listening =
+            host_query(HostQueryType::ListeningAddresses, &[]).expect("listening query");
+        let info: crate::ffi::dtos::ListeningInfo = rmp_serde::from_slice(&listening).unwrap();
+        assert_eq!(info.port, 4321);
 
         let _ = shutdown();
     }

--- a/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
@@ -283,4 +283,10 @@ namespace MusicBeePlugin.Ffi
         public string reason { get; set; }
     }
 
+    public class ListeningInfo
+    {
+        public ushort port { get; set; }
+        public List<string> addresses { get; set; }
+    }
+
 }

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -108,6 +108,7 @@ namespace MusicBeePlugin.Ffi.Generated
     {
         CacheStatus = 1,
         RecentBlocked = 2,
+        ListeningAddresses = 3,
     }
 
     public enum HostCommandType

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -366,6 +366,15 @@ namespace MusicBeePlugin.Ffi
         /// <summary>Read the core's cache status for the settings panel.</summary>
         public CoreCacheStatus ReadCacheStatus() => Query<CoreCacheStatus>(HostQueryType.CacheStatus);
 
+        /// <summary>
+        ///     The addresses a client can reach the server on (candidate
+        ///     interface IPv4s + the bound port), for the settings panel to show
+        ///     the user what to point the phone client at. Null if the core is
+        ///     not initialized or the read fails.
+        /// </summary>
+        public ListeningInfo ReadListeningAddresses() =>
+            Query<ListeningInfo>(HostQueryType.ListeningAddresses);
+
         /// <summary>Trigger a background rebuild of the metadata (browse) cache.</summary>
         public bool RebuildMetadata() => Command(HostCommandType.RebuildMetadata);
 

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -91,6 +91,12 @@ namespace MusicBeePlugin.Host
         /// <summary>The core's cache status, for the configuration panel's cache line.</summary>
         public CoreCacheStatus ReadCacheStatus() => _bridge.ReadCacheStatus();
 
+        /// <summary>
+        ///     The addresses a client can reach the server on (interface IPv4s +
+        ///     the bound port), for the configuration panel's connection group.
+        /// </summary>
+        public Ffi.ListeningInfo ReadListeningAddresses() => _bridge.ReadListeningAddresses();
+
         /// <summary>Trigger a background rebuild of the metadata (browse) cache.</summary>
         public bool RebuildMetadata() => _bridge.RebuildMetadata();
 

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -52,6 +52,7 @@ namespace MusicBeePlugin.Settings
 
         private NumericUpDown _port;
         private Label _connStatus;
+        private Label _addresses;
         private Button _testConn;
         private ComboBox _filterMode;
         private TextBox _baseIp;
@@ -83,6 +84,7 @@ namespace MusicBeePlugin.Settings
 
             BuildLayout();
             LoadFromCore();
+            LoadListeningAddresses();
             LoadCacheStatus();
             LoadBlockedCount();
             RunConnectionTest();
@@ -176,9 +178,21 @@ namespace MusicBeePlugin.Settings
             statusRow.Controls.Add(_testConn);
             statusRow.Controls.Add(_connStatus);
 
+            // Read-only list of the addresses a client can reach this server on
+            // (each interface IPv4 + the bound port), so the user knows what to
+            // enter in the phone app - as the shipped 1.4.1 panel showed.
+            _addresses = new Label
+            {
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                Padding = new Padding(0, 4, 0, 0),
+                ForeColor = SystemColors.GrayText,
+            };
+
             var layout = GroupLayout();
             AddRow(layout, "Listening port", _port);
             AddRow(layout, "Status", statusRow);
+            AddRow(layout, "Reachable at", _addresses);
             return WrapGroup("Connection", layout);
         }
 
@@ -482,6 +496,32 @@ namespace MusicBeePlugin.Settings
             _firewall.Checked = s.update_firewall;
             UpdateFilterEnabled();
             SetStatus(string.Empty, true);
+        }
+
+        /// <summary>
+        ///     Render the addresses a client can reach this server on (each
+        ///     interface IPv4 + the bound port), read from the core. Shown so the
+        ///     user knows what to enter in the phone app. The list reflects the
+        ///     running server, so it does not change while the dialog is open.
+        /// </summary>
+        private void LoadListeningAddresses()
+        {
+            var info = _host.ReadListeningAddresses();
+            if (info == null)
+            {
+                _addresses.Text = "Unavailable (core not running).";
+                return;
+            }
+
+            if (info.addresses == null || info.addresses.Count == 0)
+            {
+                _addresses.Text = "No reachable network address detected.";
+                return;
+            }
+
+            _addresses.Text = string.Join(
+                Environment.NewLine,
+                info.addresses.Select(a => a + ":" + info.port.ToString(CultureInfo.InvariantCulture)));
         }
 
         /// <summary>Read the cache status from the core and render the line.</summary>


### PR DESCRIPTION
## What

The shipped C# 1.4.1 plugin listed the candidate IP addresses the server was reachable on, so the user knew what to point the phone client at. The Rust-core Configure panel had only the listening port. This restores the address list.

## Change

New host query `HostQueryType::ListeningAddresses` returns a `ListeningInfo { port, addresses }`:

- `port` - the bound TCP port (the listener binds `0.0.0.0`, so every address below is reachable on it).
- `addresses` - the candidate interface IPv4s.

The addresses reuse discovery's `usable_ipv4_ifaces()` (loopback / unspecified / `169.254.x` link-local dropped), the **same set the discovery responder would advertise**, so what the panel shows matches what a client would auto-discover.

The enum variant and the DTO are regenerated into the C# bindings by `build.rs` (drift-guarded, not hand-edited).

The Connection group renders a `Reachable at` row listing each `address:port`, read once when the dialog opens. It reflects the running server, so it stays static while the dialog is open (like the connection test, it uses the live/bound port, not an unsaved edit in the port field). Falls back to "No reachable network address detected." on an interface-less host and "Unavailable (core not running)." if the core is down.

## FFI surface

- Rust: `ffi/types.rs` (`HostQueryType::ListeningAddresses = 3`, additive), `ffi/dtos.rs` (`ListeningInfo`), `state.rs` dispatch arm, `discovery::usable_ipv4_ifaces` made `pub(crate)`.
- Generated: `NativeBridgeEnums.Generated.cs` + `NativeBridgeDtos.Generated.cs`.
- C#: `NativeBridge.ReadListeningAddresses()`, `PluginHost.ReadListeningAddresses()`, the panel row.

No ABI bump needed (additive enum variant; `MBRC_ABI_VERSION` unchanged).

## Tests

- `ffi::types` roundtrip test extended for the new variant.
- `state` round-trip test extended: the listening query reports the in-memory bound port (address list is interface-dependent, so only the port is pinned).
- `cargo fmt`, `clippy -D warnings`, full `mbrc-core` lib suite (146 pass) green for `i686-pc-windows-msvc`; C# solution builds; `dotnet format --verify-no-changes` clean.
