### PR TITLE
ci: split release out of ci.yml, add reusable build and package action

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -1,0 +1,90 @@
+name: package
+description: >-
+  Build the NSIS installer and zip from build/dist, emit SHA512 sidecars, and
+  optionally attest build provenance. Shared by release.yml and nightly.yml so
+  the packaging logic exists once.
+
+inputs:
+  version:
+    description: 'Full version string, e.g. 1.5.0 or 1.5.0-nightly.20260729.'
+    required: true
+  attest:
+    description: 'Publish build provenance attestations. Requires id-token: write and attestations: write on the calling job.'
+    required: false
+    default: 'false'
+
+outputs:
+  installer:
+    description: 'Path to the built installer.'
+    value: ${{ steps.names.outputs.INSTALLER }}
+  zip:
+    description: 'Path to the built zip archive.'
+    value: ${{ steps.names.outputs.ZIP }}
+
+runs:
+  using: composite
+  steps:
+    - name: resolve artifact names
+      id: names
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        # build/dist is fixed rather than an input: MusicBeeRemote.nsi pulls its
+        # payload from a hardcoded ..\build\dist.
+        $base = "musicbee_remote_$env:VERSION"
+        echo "BASE=$base" >> $env:GITHUB_OUTPUT
+        echo "INSTALLER=build/dist/$base.exe" >> $env:GITHUB_OUTPUT
+        echo "ZIP=build/dist/$base.zip" >> $env:GITHUB_OUTPUT
+
+    - name: install NSIS
+      shell: pwsh
+      run: choco install nsis -y
+
+    - name: build installer
+      shell: pwsh
+      env:
+        VERSION: ${{ inputs.version }}
+        BASE: ${{ steps.names.outputs.BASE }}
+      run: |
+        # MusicBeeRemote.nsi reads PLUGIN_VERSION from the environment.
+        $env:PLUGIN_VERSION = $env:VERSION
+        & "C:\Program Files (x86)\NSIS\makensis.exe" installer\MusicBeeRemote.nsi
+        mv "installer\$env:BASE.exe" "build\dist\"
+
+    - name: create zip archive
+      shell: pwsh
+      env:
+        BASE: ${{ steps.names.outputs.BASE }}
+      run: |
+        $files = @(
+          "build\dist\mb_remote.dll",
+          "build\dist\mbrc_core.dll",
+          "build\dist\firewall-utility.exe",
+          "build\dist\LICENSE",
+          "build\dist\README.txt"
+        )
+        Compress-Archive -Path $files -DestinationPath "build\dist\$env:BASE.zip"
+
+    - name: generate checksums
+      shell: pwsh
+      env:
+        BASE: ${{ steps.names.outputs.BASE }}
+      run: |
+        foreach ($ext in @('exe', 'zip')) {
+          $name = "$env:BASE.$ext"
+          $hash = (Get-FileHash -Algorithm SHA512 "build\dist\$name").Hash.ToLower()
+          "$hash  $name" | Out-File -Encoding ascii "build\dist\$name.sha512"
+        }
+
+    - name: attest build provenance (installer)
+      if: inputs.attest == 'true'
+      uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+      with:
+        subject-path: ${{ steps.names.outputs.INSTALLER }}
+
+    - name: attest build provenance (zip)
+      if: inputs.attest == 'true'
+      uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+      with:
+        subject-path: ${{ steps.names.outputs.ZIP }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,159 @@
+name: build
+
+# Reusable build for the plugin bundle. Called by ci.yml, release.yml and
+# nightly.yml so the MSBuild + Rust steps exist in exactly one place.
+#
+# Version handling: callers pass EITHER a full `version` (release, from the tag)
+# OR a `version-suffix` appended to VersionPrefix from Directory.Build.props
+# (ci, nightly). The resolved value is passed to MSBuild as /p:Version so the
+# assembly version and the packaged filenames can never disagree, and is
+# re-exported as the `version` output for the packaging step.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'Full version, e.g. 1.5.0. A leading "v" is stripped. Wins over version-suffix.'
+        type: string
+        default: ''
+      version-suffix:
+        description: 'Prerelease suffix appended to VersionPrefix, e.g. nightly.20260729. No leading dash.'
+        type: string
+        default: ''
+      artifact-name:
+        description: 'Name of the uploaded build/dist artifact.'
+        type: string
+        required: true
+      run-format-check:
+        description: 'Run dotnet format --verify-no-changes.'
+        type: boolean
+        default: false
+      run-tests:
+        description: 'Run the xUnit suite.'
+        type: boolean
+        default: false
+      upload-coverage:
+        description: 'Upload coverage to Codecov. Requires run-tests and the CODECOV_TOKEN secret.'
+        type: boolean
+        default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+    outputs:
+      version:
+        description: 'The resolved full version string.'
+        value: ${{ jobs.build.outputs.version }}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build & test
+    runs-on: windows-latest
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: setup MSBuild
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+
+      - name: setup .NET
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          dotnet-version: '10.0.x'  # kept in sync with global.json
+
+      - name: setup NuGet
+        uses: nuget/setup-nuget@fd55a6f3b34392fa83fde1454582407d8c714123 # v4.0
+
+      # The plugin build invokes build.ps1 -Rust (MSBuild BuildRustCore target),
+      # which compiles mbrc_core.dll for i686. The runner ships Rust; we just add
+      # the 32-bit target the plugin links against.
+      - name: setup Rust (i686 target)
+        run: rustup target add i686-pc-windows-msvc
+
+      - name: cache Rust build
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: restore packages
+        run: nuget restore MBRC.sln -OutputDirectory .nuget -NonInteractive -LockedMode
+
+      - name: resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SUFFIX: ${{ inputs.version-suffix }}
+        run: |
+          if ($env:INPUT_VERSION) {
+            $version = $env:INPUT_VERSION -replace '^v', ''
+          } else {
+            $xml = [xml](Get-Content Directory.Build.props)
+            $prefix = ($xml.Project.PropertyGroup.VersionPrefix | Where-Object { $_ }).Trim()
+            if (-not $prefix) {
+              Write-Error "VersionPrefix not found in Directory.Build.props"
+              exit 1
+            }
+            if ($env:INPUT_SUFFIX) {
+              # Single dash: MSBuild's own VersionPrefix/VersionSuffix join uses one,
+              # and the packaged filenames are derived from this same string.
+              $version = "$prefix-$($env:INPUT_SUFFIX)"
+            } else {
+              $version = $prefix
+            }
+          }
+          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
+          echo "Building version: $version"
+
+      - name: check code formatting
+        if: inputs.run-format-check
+        run: |
+          echo "Checking code formatting..."
+          echo "Running dotnet format --exclude=firewall-utility --verify-no-changes"
+          dotnet format --exclude="firewall-utility" --verify-no-changes --verbosity normal
+          if ($LASTEXITCODE -ne 0) {
+            echo "❌ Code formatting issues found! Run 'dotnet format --exclude=firewall-utility' to fix them."
+            echo "Note: Some analyzer warnings (CA####) are expected and don't affect formatting."
+            exit 1
+          }
+          echo "✅ Code formatting is clean!"
+
+      - name: build with strict analysis
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+        run: |
+          echo "🔍 Building with strict static analysis (warnings as errors)..."
+          msbuild MBRC.sln /p:Configuration="Release" /p:MSBuildCI="true" /p:Version=$env:VERSION /m /v:M /fl /nr:false
+
+      - name: run tests with coverage
+        if: inputs.run-tests
+        run: |
+          dotnet test tests/csharp/MusicBeeRemote.Core.Tests.csproj --configuration Release --collect:"XPlat Code Coverage" --results-directory ./TestResults
+
+      - name: upload coverage to Codecov
+        if: inputs.run-tests && inputs.upload-coverage
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./TestResults
+          flags: csharp
+          fail_ci_if_error: false
+          verbose: true
+
+      - name: copy to dist
+        run: |
+          mkdir -p build/dist
+          cp build/bin/plugin/Release/net48/mb_remote.dll build/dist
+          # Native core (Release -> the `plugin` cargo profile); must ship next to
+          # mb_remote.dll. Not embedded by Costura (managed-only).
+          cp target/i686-pc-windows-msvc/plugin/mbrc_core.dll build/dist
+          cp build/bin/firewall-utility/Release/net48/firewall-utility.exe build/dist
+          cp LICENSE build/dist
+          cp installer/README.txt build/dist
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: build/dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,225 +3,27 @@ name: ci
 on:
   push:
     branches: [ main ]
-    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
 
-# Least-privilege default; jobs opt into more only where needed (see release).
+# Least-privilege default.
 permissions:
   contents: read
 
-# Cancel superseded runs on a branch/PR; let tag (release) runs finish.
+# Cancel superseded runs on a branch/PR.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
-    name: build & test
-    runs-on: windows-latest
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: setup MSBuild
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
-
-      - name: setup .NET
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
-        with:
-          dotnet-version: '10.0.x'  # kept in sync with global.json
-
-      - name: setup NuGet
-        uses: nuget/setup-nuget@fd55a6f3b34392fa83fde1454582407d8c714123 # v4.0
-
-      # The plugin build invokes build.ps1 -Rust (MSBuild BuildRustCore target),
-      # which compiles mbrc_core.dll for i686. The runner ships Rust; we just add
-      # the 32-bit target the plugin links against.
-      - name: setup Rust (i686 target)
-        run: rustup target add i686-pc-windows-msvc
-
-      - name: cache Rust build
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - name: restore packages
-        run: nuget restore MBRC.sln -OutputDirectory .nuget -NonInteractive -LockedMode
-
-      - name: determine version
-        id: version
-        env:
-          GH_REF: ${{ github.ref }}
-          GH_REF_NAME: ${{ github.ref_name }}
-          GH_RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          if ($env:GH_REF.StartsWith("refs/tags/v")) {
-            $version = $env:GH_REF_NAME -replace '^v', ''
-            echo "VERSION=$version" >> $env:GITHUB_OUTPUT
-            echo "VERSION_ARGS=/p:Version=$version" >> $env:GITHUB_OUTPUT
-            echo "Building release version: $version"
-          } else {
-            # For non-tag builds, use VersionPrefix from Directory.Build.props with nightly suffix
-            $suffix = "nightly.$env:GH_RUN_NUMBER"
-            echo "VERSION_ARGS=/p:VersionSuffix=$suffix" >> $env:GITHUB_OUTPUT
-            echo "Building development version with suffix: $suffix"
-          }
-
-      - name: check code formatting
-        run: |
-          echo "Checking code formatting..."
-          echo "Running dotnet format --exclude=firewall-utility --verify-no-changes"
-          dotnet format --exclude="firewall-utility" --verify-no-changes --verbosity normal
-          if ($LASTEXITCODE -ne 0) {
-            echo "❌ Code formatting issues found! Run 'dotnet format --exclude=firewall-utility' to fix them."
-            echo "Note: Some analyzer warnings (CA####) are expected and don't affect formatting."
-            exit 1
-          }
-          echo "✅ Code formatting is clean!"
-
-      - name: build with strict analysis
-        env:
-          VERSION_ARGS: ${{ steps.version.outputs.VERSION_ARGS }}
-        run: |
-          echo "🔍 Building with strict static analysis (warnings as errors)..."
-          msbuild MBRC.sln /p:Configuration="Release" /p:MSBuildCI="true" $env:VERSION_ARGS /m /v:M /fl /nr:false
-
-      - name: static analysis passed
-        run: |
-          echo "✅ Static Analysis Passed!"
-          echo "All critical analyzer rules passed validation."
-          echo "Build completed with only low-priority warnings (if any)."
-
-      - name: run tests with coverage
-        run: |
-          dotnet test tests/csharp/MusicBeeRemote.Core.Tests.csproj --configuration Release --collect:"XPlat Code Coverage" --results-directory ./TestResults
-
-      - name: upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./TestResults
-          flags: csharp
-          fail_ci_if_error: false
-          verbose: true
-
-      - name: copy to dist
-        run: |
-          mkdir -p build/dist
-          cp build/bin/plugin/Release/net48/mb_remote.dll build/dist
-          # Native core (Release -> the `plugin` cargo profile); must ship next to
-          # mb_remote.dll. Not embedded by Costura (managed-only).
-          cp target/i686-pc-windows-msvc/plugin/mbrc_core.dll build/dist
-          cp build/bin/firewall-utility/Release/net48/firewall-utility.exe build/dist
-          cp LICENSE build/dist
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: mbrc-plugin-dev
-          path: build/dist
-
-  release:
-    name: release
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: windows-latest
-    permissions:
-      contents: write      # create the GitHub release and upload its assets
-      id-token: write      # OIDC token used to sign the build provenance attestation
-      attestations: write  # publish the provenance attestation
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: download build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: mbrc-plugin-dev
-          path: build/dist
-
-      - name: set version from tag
-        id: version
-        env:
-          GH_REF_NAME: ${{ github.ref_name }}
-        run: |
-          $version = $env:GH_REF_NAME -replace '^v', ''
-          echo "VERSION=$version" >> $env:GITHUB_OUTPUT
-          echo "Version: $version"
-
-      - name: install NSIS
-        run: choco install nsis -y
-
-      - name: build installer
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-        run: |
-          $env:PLUGIN_VERSION = $env:VERSION
-          & "C:\Program Files (x86)\NSIS\makensis.exe" installer\MusicBeeRemote.nsi
-
-      - name: move installer to dist
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-        run: |
-          $version = $env:VERSION
-          mv "installer\musicbee_remote_$version.exe" "build\dist\"
-
-      - name: create zip archive
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-        run: |
-          $version = $env:VERSION
-          cp installer\README.txt build\dist\
-          Compress-Archive -Path "build\dist\mb_remote.dll", "build\dist\mbrc_core.dll", "build\dist\firewall-utility.exe", "build\dist\LICENSE", "build\dist\README.txt" -DestinationPath "build\dist\musicbee_remote_$version.zip"
-
-      - name: generate checksums
-        env:
-          VERSION: ${{ steps.version.outputs.VERSION }}
-        run: |
-          $version = $env:VERSION
-          cd build\dist
-          (Get-FileHash -Algorithm SHA512 "musicbee_remote_$version.exe").Hash.ToLower() + "  musicbee_remote_$version.exe" | Out-File -Encoding ascii "musicbee_remote_$version.exe.sha512"
-          (Get-FileHash -Algorithm SHA512 "musicbee_remote_$version.zip").Hash.ToLower() + "  musicbee_remote_$version.zip" | Out-File -Encoding ascii "musicbee_remote_$version.zip.sha512"
-
-      - name: attest build provenance (exe)
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: build/dist/musicbee_remote_${{ steps.version.outputs.VERSION }}.exe
-
-      - name: attest build provenance (zip)
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: build/dist/musicbee_remote_${{ steps.version.outputs.VERSION }}.zip
-
-      - name: create GitHub release
-        # zizmor: ignore[superfluous-actions] — kept intentionally: the action bundles
-        # release-notes generation + multi-asset upload that a raw `gh release` step would reimplement.
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
-        with:
-          files: |
-            build/dist/musicbee_remote_${{ steps.version.outputs.VERSION }}.exe
-            build/dist/musicbee_remote_${{ steps.version.outputs.VERSION }}.exe.sha512
-            build/dist/musicbee_remote_${{ steps.version.outputs.VERSION }}.zip
-            build/dist/musicbee_remote_${{ steps.version.outputs.VERSION }}.zip.sha512
-          generate_release_notes: true
-          body: |
-            See the [CHANGELOG](https://github.com/musicbeeremote/mbrc-plugin/blob/main/CHANGELOG.md) for details.
-
-            ## MusicBee Microsoft Store version
-
-            If you are using the Microsoft Store version of MusicBee, install the plugin using the zip file.
-
-            Go to MusicBee -> Edit -> Preferences -> Plugins and use the "Add Plugin" button to install directly from the zip file.
-
-            ## Verify integrity
-
-            To verify the downloaded file integrity you can use Windows PowerShell:
-
-            ```powershell
-            cd Downloads
-            Get-FileHash -Path .\musicbee_remote_${{ steps.version.outputs.VERSION }}.exe -Algorithm SHA512
-            ```
-
-            Ensure that the Hash matches the one in the corresponding `.sha512` file.
+    name: build
+    uses: ./.github/workflows/build.yml
+    with:
+      version-suffix: nightly.${{ github.run_number }}
+      artifact-name: mbrc-plugin-dev
+      run-format-check: true
+      run-tests: true
+      upload-coverage: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -81,71 +81,33 @@ jobs:
     name: build nightly
     needs: check
     if: needs.check.outputs.should_build == 'true'
+    uses: ./.github/workflows/build.yml
+    with:
+      version-suffix: nightly.${{ needs.check.outputs.version }}
+      artifact-name: nightly-dist-${{ needs.check.outputs.version }}
+
+  package:
+    name: package nightly
+    needs: [ check, build ]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
-      - name: setup MSBuild
-        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3.0.0
+      - name: download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: nightly-dist-${{ needs.check.outputs.version }}
+          path: build/dist
 
-      - name: setup NuGet
-        uses: nuget/setup-nuget@fd55a6f3b34392fa83fde1454582407d8c714123 # v4.0
-
-      # The plugin build compiles mbrc_core.dll for i686 via build.ps1 -Rust.
-      - name: setup Rust (i686 target)
-        run: rustup target add i686-pc-windows-msvc
-
-      - name: cache Rust build
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - name: restore packages
-        run: nuget restore MBRC.sln -OutputDirectory .nuget -NonInteractive -LockedMode
-
-      - name: build
-        env:
-          NIGHTLY_VERSION: ${{ needs.check.outputs.version }}
-        run: |
-          $version = $env:NIGHTLY_VERSION
-          msbuild MBRC.sln /p:Configuration="Release" /p:VersionSuffix="-nightly.$version" /m /v:M /nr:false
-
-      - name: prepare artifacts
-        run: |
-          mkdir -p build/dist
-          cp build/bin/plugin/Release/net48/mb_remote.dll build/dist
-          cp target/i686-pc-windows-msvc/plugin/mbrc_core.dll build/dist
-          cp build/bin/firewall-utility/Release/net48/firewall-utility.exe build/dist
-          cp LICENSE build/dist
-          cp installer/README.txt build/dist
-
-      - name: install NSIS
-        run: choco install nsis -y
-
-      - name: get version prefix
-        id: version_prefix
-        run: |
-          $xml = [xml](Get-Content Directory.Build.props)
-          $prefix = $xml.Project.PropertyGroup.VersionPrefix
-          echo "PREFIX=$prefix" >> $env:GITHUB_OUTPUT
-
-      - name: build installer
-        env:
-          VERSION_PREFIX: ${{ steps.version_prefix.outputs.PREFIX }}
-          NIGHTLY_VERSION: ${{ needs.check.outputs.version }}
-        run: |
-          $version = "${env:VERSION_PREFIX}-nightly.${env:NIGHTLY_VERSION}"
-          $env:PLUGIN_VERSION = $version
-          & "C:\Program Files (x86)\NSIS\makensis.exe" installer\MusicBeeRemote.nsi
-          mv "installer\musicbee_remote_$version.exe" "build\dist\"
-
-      - name: create zip
-        env:
-          VERSION_PREFIX: ${{ steps.version_prefix.outputs.PREFIX }}
-          NIGHTLY_VERSION: ${{ needs.check.outputs.version }}
-        run: |
-          $version = "${env:VERSION_PREFIX}-nightly.${env:NIGHTLY_VERSION}"
-          Compress-Archive -Path "build\dist\mb_remote.dll", "build\dist\mbrc_core.dll", "build\dist\firewall-utility.exe", "build\dist\LICENSE", "build\dist\README.txt" -DestinationPath "build\dist\musicbee_remote_$version.zip"
+      # Attestation stays off until nightlies publish to a real release
+      # (rolling `nightly` tag) rather than a 7-day workflow artifact. See #148.
+      - name: package
+        uses: ./.github/actions/package
+        with:
+          version: ${{ needs.build.outputs.version }}
+          attest: 'false'
 
       - name: upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -154,4 +116,5 @@ jobs:
           path: |
             build/dist/*.exe
             build/dist/*.zip
+            build/dist/*.sha512
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: release
+
+on:
+  push:
+    tags: [ 'v*' ]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build, e.g. 1.5.0. Dry runs only; no release is published.'
+        type: string
+        required: true
+
+# Least-privilege default; the publish job opts into more.
+permissions:
+  contents: read
+
+# Let a tag run finish rather than cancelling it mid-publish.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/build.yml
+    with:
+      version: ${{ inputs.version || github.ref_name }}
+      artifact-name: mbrc-plugin-release
+      run-format-check: true
+      run-tests: true
+
+  publish:
+    name: publish
+    needs: build
+    runs-on: windows-latest
+    environment: release
+    permissions:
+      contents: write      # create the GitHub release and upload its assets
+      id-token: write      # OIDC token used to sign the build provenance attestation
+      attestations: write  # publish the provenance attestation
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # The bundle is downloaded rather than rebuilt so the bytes that get
+      # hashed, attested and published are the exact bytes that were tested.
+      - name: download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mbrc-plugin-release
+          path: build/dist
+
+      - name: package
+        id: package
+        uses: ./.github/actions/package
+        with:
+          version: ${{ needs.build.outputs.version }}
+          attest: 'true'
+
+      - name: create GitHub release
+        # Dry runs (workflow_dispatch) build and attest but never publish.
+        if: startsWith(github.ref, 'refs/tags/v')
+        # zizmor: ignore[superfluous-actions] — kept intentionally: the action bundles
+        # release-notes generation + multi-asset upload that a raw `gh release` step would reimplement.
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          files: |
+            ${{ steps.package.outputs.installer }}
+            ${{ steps.package.outputs.installer }}.sha512
+            ${{ steps.package.outputs.zip }}
+            ${{ steps.package.outputs.zip }}.sha512
+          generate_release_notes: true
+          body: |
+            See the [CHANGELOG](https://github.com/musicbeeremote/mbrc-plugin/blob/main/CHANGELOG.md) for details.
+
+            ## MusicBee Microsoft Store version
+
+            If you are using the Microsoft Store version of MusicBee, install the plugin using the zip file.
+
+            Go to MusicBee -> Edit -> Preferences -> Plugins and use the "Add Plugin" button to install directly from the zip file.
+
+            ## Verify integrity
+
+            To verify the downloaded file integrity you can use Windows PowerShell:
+
+            ```powershell
+            cd Downloads
+            Get-FileHash -Path .\musicbee_remote_${{ needs.build.outputs.version }}.exe -Algorithm SHA512
+            ```
+
+            Ensure that the Hash matches the one in the corresponding `.sha512` file.


### PR DESCRIPTION
Closes #146. First prerequisite for the auto-update epic (#24).

## What

`ci.yml` and `nightly.yml` duplicated the same eight build steps, and the release
job lived inside `ci.yml` behind a `startsWith(github.ref, 'refs/tags/v')` guard.
This extracts both shared halves so the release pipeline stands on its own and can
grow manifest generation and signing in #147.

**New**

- `.github/workflows/build.yml` — `workflow_call` reusable holding the build steps.
  Inputs: `version` or `version-suffix`, `artifact-name`, and toggles for the format
  check, tests, and coverage upload. Outputs the resolved version.
- `.github/actions/package/action.yml` — composite: NSIS installer, zip, SHA512
  sidecars, optional provenance attestation. Outputs the installer and zip paths.

**Rewritten**

- `ci.yml` — 222 lines to 29. Push/PR only, calls `build.yml` with the format check,
  tests, and coverage on. Tag trigger and release job removed.
- `release.yml` — tags `v*` plus a `workflow_dispatch` dry run. Downloads the build
  job's artifact rather than rebuilding, so the bytes hashed, attested, and published
  are the bytes that were tested. Runs under a `release` environment.
- `nightly.yml` — `check` job untouched; build and packaging now go through the
  shared pieces. Keeps its 7-day artifacts, gains SHA512 sidecars.

## Bug fixed in passing

Nightly passed `/p:VersionSuffix="-nightly.<date>"` with a leading dash, and MSBuild
joins `VersionPrefix` and `VersionSuffix` with its own dash. The assembly version
came out as `1.5.0--nightly.20260729` while the packaged filenames used the
single-dash form.

Both paths now resolve one full version string and pass it as `/p:Version`, so the
assembly version and the filenames cannot disagree. This matters beyond tidiness:
the updater compares against the assembly version over FFI
(`QueryType::PluginVersion`).

## Behaviour changes

- Nightly artifacts now include `.sha512` sidecars.
- Nightly attestation stays **off** until nightlies publish to a real release tag
  rather than a 7-day workflow artifact (#148).
- `release.yml` gains a `workflow_dispatch` dry run that builds, packages, and
  attests but never publishes; the release step is gated on `refs/tags/v`.
- Otherwise the published release assets are unchanged: installer, zip, both
  `.sha512` files, and provenance attestations.

## Verification

- `actionlint` clean (the only output is a pre-existing SC2086 in nightly's untouched
  `check` job)
- `zizmor --persona=pedantic` clean
- The PR run itself exercises `build.yml` through `ci.yml`, the shared path all three
  callers use. `release.yml` and the package action are covered by a
  `workflow_dispatch` dry run after merge.

## Follow-up needed on the repo settings

- [ ] Create the `release` environment with required reviewers. It auto-creates on
      first run, but an environment with no protection rules is not a gate, and this
      is what makes #147's minisign private key safe to store.
- [ ] If required status checks reference `ci / build & test`, the name is now
      `build / build & test`: reusable workflow jobs are prefixed with the caller's
      job id.
