### PR TITLE
fix(server): bind loopback in tests, skip discovery when not on a LAN address

### DIFF
--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -61,6 +61,11 @@ impl LogLevel {
     }
 }
 
+/// Listen on every interface. Clients are phones elsewhere on the LAN.
+fn default_bind_address() -> String {
+    "0.0.0.0".to_string()
+}
+
 fn default_ping_interval_secs() -> u64 {
     15
 }
@@ -88,6 +93,22 @@ fn default_tcp_keepalive_secs() -> u64 {
 pub struct Config {
     /// TCP port the command server listens on.
     pub port: u16,
+    /// Local address the command server binds to.
+    ///
+    /// `0.0.0.0` in production: the whole point of the plugin is to accept
+    /// connections from phones on the LAN, so it must listen on every
+    /// interface. The field exists so tests can bind loopback instead.
+    ///
+    /// That is not cosmetic. A listener on `0.0.0.0` makes Windows Firewall
+    /// raise its "allow this app?" prompt, and it raises it per *program path*.
+    /// Cargo puts a fresh hash in every test binary's filename, so each rebuild
+    /// looked like a brand new program and left behind another firewall rule.
+    /// Loopback listeners are never filtered and never prompt.
+    ///
+    /// An unparseable value falls back to `0.0.0.0` rather than refusing to
+    /// start: a typo in `core_settings.json` should not leave the user with a
+    /// plugin that silently never listens.
+    pub bind_address: String,
     /// The client-address filtering mode (`all` / `range` / `specific`).
     pub filter_mode: FilterMode,
     /// Range mode: the base IPv4 whose first three octets bound the /24; its
@@ -136,10 +157,31 @@ pub struct Config {
     pub storage_path: String,
 }
 
+impl Config {
+    /// A config for integration tests: defaults, but bound to loopback.
+    ///
+    /// Tests must not bind `0.0.0.0`. Doing so makes Windows Firewall prompt
+    /// for every test binary, and since Cargo rebuilds them under a new hash
+    /// each time, every rebuild leaves another stale rule behind. Loopback is
+    /// never filtered, so the prompt never appears and the tests are unaffected
+    /// - they connect to `127.0.0.1` regardless.
+    ///
+    /// This lives here rather than in each test file so a new test gets the
+    /// right behaviour by reaching for the obvious constructor.
+    pub fn for_test(port: u16) -> Self {
+        Self {
+            port,
+            bind_address: "127.0.0.1".to_string(),
+            ..Self::default()
+        }
+    }
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
             port: default_port(),
+            bind_address: default_bind_address(),
             filter_mode: FilterMode::default(),
             base_ip: String::new(),
             last_octet_max: default_last_octet_max(),

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -83,7 +83,21 @@ fn run_thread(
     };
 
     runtime.block_on(async move {
-        let listener = match TcpListener::bind(("0.0.0.0", core.config.port)).await {
+        // A bad address in core_settings.json falls back to listening on every
+        // interface rather than refusing to start, since a plugin that silently
+        // never listens is the worst of the available failures.
+        let bind_ip: std::net::IpAddr = match core.config.bind_address.parse() {
+            Ok(ip) => ip,
+            Err(_) => {
+                tracing::warn!(
+                    bind_address = %core.config.bind_address,
+                    "invalid bind_address; falling back to 0.0.0.0"
+                );
+                std::net::IpAddr::from([0, 0, 0, 0])
+            }
+        };
+
+        let listener = match TcpListener::bind((bind_ip, core.config.port)).await {
             Ok(listener) => {
                 let _ = ready.send(Ok(()));
                 listener
@@ -93,9 +107,25 @@ fn run_thread(
                 return;
             }
         };
-        tracing::info!(port = core.config.port, "command server listening");
+        tracing::info!(
+            %bind_ip,
+            port = core.config.port,
+            "command server listening"
+        );
 
-        let discovery = tokio::spawn(crate::discovery::run(core.config.port, shutdown.clone()));
+        // Discovery advertises this host to the LAN over UDP multicast, which
+        // makes no sense for a loopback-only listener that nothing off-box can
+        // reach anyway. Skipping it also keeps it from binding INADDR_ANY and
+        // raising the Windows Firewall prompt during tests.
+        let discovery = if bind_ip.is_loopback() {
+            tracing::debug!("discovery responder skipped (bound to loopback)");
+            None
+        } else {
+            Some(tokio::spawn(crate::discovery::run(
+                core.config.port,
+                shutdown.clone(),
+            )))
+        };
         let monitor = tokio::spawn(monitor::run(core.clone(), shutdown.clone()));
         let scanner = tokio::spawn(scanner::run(core.clone(), shutdown.clone()));
 
@@ -118,7 +148,9 @@ fn run_thread(
             _ = accept_loop(listener, core.clone()) => {}
             _ = shutdown.notified() => tracing::info!("networking shutdown requested"),
         }
-        discovery.abort();
+        if let Some(discovery) = discovery {
+            discovery.abort();
+        }
         monitor.abort();
         scanner.abort();
     });

--- a/packages/mbrc-core/tests/golden_replay.rs
+++ b/packages/mbrc-core/tests/golden_replay.rs
@@ -488,10 +488,7 @@ fn assert_golden_covered(golden_path: &str, client_type_hint: &str) {
     let port = free_port();
     let core = Arc::new(Core::new(
         Arc::new(FixtureProviders),
-        Config {
-            port,
-            ..Config::default()
-        },
+        Config::for_test(port),
     ));
     // The paginated `libraryalbumcover` is served from the CoverStore. The test
     // Config has no storage path, so the background build is skipped; pre-warm

--- a/packages/mbrc-core/tests/handshake.rs
+++ b/packages/mbrc-core/tests/handshake.rs
@@ -25,13 +25,7 @@ fn free_port() -> u16 {
 #[test]
 fn server_completes_v4_handshake_and_keepalive() {
     let port = free_port();
-    let core = Arc::new(Core::new(
-        Arc::new(NullProviders),
-        Config {
-            port,
-            ..Config::default()
-        },
-    ));
+    let core = Arc::new(Core::new(Arc::new(NullProviders), Config::for_test(port)));
     let net = server::start(core).expect("server should bind and start");
 
     let mut writer = TcpStream::connect(("127.0.0.1", port)).expect("connect");
@@ -84,13 +78,7 @@ fn server_completes_v4_handshake_and_keepalive() {
 #[test]
 fn server_rejects_pre_v4_client() {
     let port = free_port();
-    let core = Arc::new(Core::new(
-        Arc::new(NullProviders),
-        Config {
-            port,
-            ..Config::default()
-        },
-    ));
+    let core = Arc::new(Core::new(Arc::new(NullProviders), Config::for_test(port)));
     let net = server::start(core).expect("server should bind and start");
 
     let mut writer = TcpStream::connect(("127.0.0.1", port)).expect("connect");
@@ -127,10 +115,9 @@ fn reaps_idle_connection_that_never_handshakes() {
     let core = Arc::new(Core::new(
         Arc::new(NullProviders),
         Config {
-            port,
             ping_interval_secs: 1,
             unhandshaked_timeout_secs: 2,
-            ..Config::default()
+            ..Config::for_test(port)
         },
     ));
     let net = server::start(core).expect("server should bind and start");
@@ -179,9 +166,8 @@ fn broadcast_subscriber_is_not_reaped_while_silent() {
     let core = Arc::new(Core::new(
         Arc::new(NullProviders),
         Config {
-            port,
             ping_interval_secs: 1,
-            ..Config::default()
+            ..Config::for_test(port)
         },
     ));
     let net = server::start(core).expect("server should bind and start");
@@ -249,10 +235,9 @@ fn aux_socket_gets_no_ping_and_is_not_reaped_while_idle() {
     let core = Arc::new(Core::new(
         Arc::new(NullProviders),
         Config {
-            port,
             ping_interval_secs: 1,
             unhandshaked_timeout_secs: 2,
-            ..Config::default()
+            ..Config::for_test(port)
         },
     ));
     let net = server::start(core).expect("server should bind and start");
@@ -316,13 +301,7 @@ fn new_main_supersedes_old_main_of_same_client() {
     // Two main (broadcast) connections carrying the same client_id: the newer one
     // supersedes the older, which the server closes.
     let port = free_port();
-    let core = Arc::new(Core::new(
-        Arc::new(NullProviders),
-        Config {
-            port,
-            ..Config::default()
-        },
-    ));
+    let core = Arc::new(Core::new(Arc::new(NullProviders), Config::for_test(port)));
     let net = server::start(core).expect("server should bind and start");
 
     let handshake = concat!(
@@ -374,13 +353,7 @@ fn new_main_supersedes_old_main_of_same_client() {
 #[test]
 fn broadcast_reaches_a_handshaked_client() {
     let port = free_port();
-    let core = Arc::new(Core::new(
-        Arc::new(NullProviders),
-        Config {
-            port,
-            ..Config::default()
-        },
-    ));
+    let core = Arc::new(Core::new(Arc::new(NullProviders), Config::for_test(port)));
     let net = server::start(core.clone()).expect("server should bind and start");
 
     let mut writer = TcpStream::connect(("127.0.0.1", port)).expect("connect");


### PR DESCRIPTION
Running the Rust test suite raised a Windows Firewall prompt and left a stale rule behind
per test binary, so the rule list slowly filled with `handshake-<hash>.exe` and
`golden_replay-<hash>.exe` entries.

## Two listeners, not one

Fixing only the first is not enough, which is why a partial fix still prompted:

1. `server::start` hardcoded `TcpListener::bind(("0.0.0.0", port))`, so every test that
   started a server listened on all interfaces.
2. It also spawns the UDP discovery responder, which binds `INADDR_ANY` on 45345 and joins
   multicast on every usable interface. That is an independent prompt and survives any
   change to the TCP bind.

Rules accumulate because Windows scopes the prompt to the *program path*, and Cargo puts a
metadata hash in each test binary's filename. The hash changes whenever a crate's
dependencies, features or profile change -- not on every rebuild -- so the entries build up
gradually rather than per build.

## The change

`bind_address` is now a config field defaulting to `0.0.0.0`. Production must keep
listening on every interface: the clients are phones elsewhere on the LAN, so this is not
something to "fix" outside tests. `Config::for_test(port)` sets loopback, and both
integration suites use it.

Loopback listeners are never filtered by Windows Firewall, so no prompt appears and no
rule is created. The tests are otherwise unaffected -- they already connected to
`127.0.0.1` regardless of what the server bound to.

Discovery is skipped when the bind address is loopback. That is not a test special-case:
advertising over LAN multicast is meaningless for a listener nothing off-box can reach.

An unparseable `bind_address` falls back to `0.0.0.0` with a warning rather than refusing
to start. A typo in `core_settings.json` should not leave a user with a plugin that
silently never listens.

`Config::for_test` lives in the core rather than being repeated in each test file, so a
new test gets the right behaviour by reaching for the obvious constructor instead of
having to know this history.

## Verification

The sockets were observed directly while each test binary ran, before and after:

| binary | TCP listen | UDP bound |
|---|---|---|
| `handshake` | `127.0.0.1` | none |
| `golden_replay` | `127.0.0.1` | none |

Previously both listened on `0.0.0.0` and discovery held a UDP endpoint on 45345.

Full suite passes. Confirmed independently by @kelsos running the suite interactively with
no firewall prompt.

## Note for reviewers

`bind_address` is deliberately not surfaced in the Configure panel. It is settable by
hand-editing `core_settings.json` for anyone who wants to restrict the listener to one
interface, but exposing it as a UI option is a separate decision about whether that is a
feature worth supporting.
