### PR TITLE
feat(update): check, download, and stage updates in the core (#149)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mbrc-buildinfo"
+version = "0.1.0"
+
+[[package]]
 name = "mbrc-capture"
 version = "0.1.0"
 dependencies = [
@@ -444,7 +448,9 @@ dependencies = [
  "flate2",
  "if-addrs",
  "image",
+ "mbrc-buildinfo",
  "mbrc-capture",
+ "mbrc-release",
  "mbrc-wire",
  "memory-stats",
  "proptest",
@@ -455,6 +461,7 @@ dependencies = [
  "sha1",
  "socket2",
  "syn",
+ "time",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -473,6 +480,7 @@ dependencies = [
 name = "mbrc-helper"
 version = "0.1.0"
 dependencies = [
+ "mbrc-buildinfo",
  "mbrc-release",
  "windows",
 ]
@@ -481,11 +489,15 @@ dependencies = [
 name = "mbrc-release"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "hex",
  "minisign-verify",
+ "semver",
  "serde",
  "serde_json",
  "sha2",
+ "time",
+ "zip",
 ]
 
 [[package]]
@@ -802,6 +814,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,6 +1379,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "packages/mbrc-buildinfo",
     "packages/mbrc-core",
     "packages/mbrc-release",
     "packages/mbrc-helper",
@@ -37,8 +38,13 @@ time = { version = "=0.3.53", features = ["formatting"] }
 if-addrs = "=0.15.0"
 mbrc-wire = { path = "packages/mbrc-wire" }
 mbrc-capture = { path = "packages/mbrc-capture" }
+mbrc-buildinfo = { path = "packages/mbrc-buildinfo" }
 mbrc-discovery = { path = "packages/mbrc-discovery" }
-mbrc-release = { path = "packages/mbrc-release" }
+# default-features = false so the helper gets only the manifest verifier; the
+# core opts into `client` (the check/download/stage half) explicitly. Declared
+# here rather than per-member because Cargo does not let a member turn off a
+# workspace dependency's default features.
+mbrc-release = { path = "packages/mbrc-release", default-features = false }
 
 # Size-optimised release build; only affects `--release` (cargo test uses dev).
 [profile.release]

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -60,6 +60,69 @@ plugin and installer actually enforce.
 `LICENSE` and `README.txt` ride along in the zip but are not listed, because they
 are not installed.
 
+## Checking
+
+The core asks GitHub for the channel's release, verifies the manifest's
+signature, and only then compares versions. Nothing is decided on unverified
+bytes and nothing is downloaded on the strength of a version number.
+
+| | stable | nightly |
+|---|---|---|
+| Endpoint | `releases/latest` | `releases/tags/nightly` |
+| Manifest `channel` must be | `stable` | `nightly` |
+
+The version the check compares against is the running plugin's, reported over FFI
+as a four-component .NET string (`1.5.0.0`). Only major.minor.patch has ever been
+meaningful here, so it is normalized to three parts before it reaches `semver`,
+which cannot parse four. Prerelease suffixes are kept, which is what makes a
+nightly order correctly: `1.7.0-nightly.20260804` is below `1.7.0` and above
+`1.6.0`, so a nightly user is offered the release it is a prerelease of and never
+an older stable.
+
+Checks are rate-limited by an interval (24 hours by default) and by an `ETag`:
+the release document is requested with `If-None-Match`, and a `304` ends the
+check without downloading or verifying anything. GitHub allows 60 unauthenticated
+requests an hour per IP, which a daily check never approaches. A failed check
+backs off - 15 minutes, doubling to a cap - so a machine that is offline retries
+sooner than the interval but does not retry on every tick.
+
+What the check has done - the last check time, the cached `ETag`, a version the
+user skipped - is written to `update_state.json`, not to `core_settings.json`.
+Those are not preferences, and keeping them out of the settings file means a save
+from the Configure panel cannot silently un-skip a release.
+
+## Staging
+
+A verified update is downloaded and unpacked to
+`%APPDATA%\MusicBee\mb_remote\updates\<version>\`, which the NSIS uninstaller
+already removes wholesale. The zip is verified against the manifest's hash before
+it is opened, and every file is verified after extraction; `pending.json` is
+written last, so its presence means the whole bundle checked out.
+
+Staging runs unelevated but everything it writes is later read by a process
+running as administrator, so the boundaries are part of the design:
+
+- **One directory, derived rather than supplied.** No caller passes a destination
+  in. `<version>` and every filename must be a bare filename before it becomes a
+  path segment, so nothing out of the manifest or the archive can name a
+  directory of its own choosing.
+- **Nothing is followed.** The staging directories are refused if they exist as
+  symlinks or junctions. Otherwise anyone able to create a reparse point in
+  `%APPDATA%` could aim the unelevated write, and the elevated copy that follows
+  it, somewhere neither of us chose.
+- **The whole archive is refused over one bad name.** An entry that is not a bare
+  filename fails the bundle rather than being skipped: CI produces a flat zip, so
+  anything else means the bytes are not what the manifest describes. Entries that
+  are safe but unlisted (`LICENSE`, `README.txt`) are simply never extracted.
+- **`pending.json` contains no paths.** It names a version. The helper derives the
+  storage directory itself and re-checks that version is a bare filename before
+  joining it, so a tampered marker can name a directory that does not exist but
+  cannot name one outside the staging root.
+- **Staging-time verification is not apply-time verification.** The staged files
+  sit somewhere an unelevated process can write, so the signed `manifest.json` and
+  its `.minisig` are staged alongside them and the helper re-verifies from those
+  before copying anything into the plugins directory.
+
 ## Signing
 
 minisign (ed25519). Authenticode was rejected on cost, and GPG on the verifier

--- a/packages/mbrc-buildinfo/Cargo.toml
+++ b/packages/mbrc-buildinfo/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "mbrc-buildinfo"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+publish = false
+description = "Build-script helper: stamps the product version from Directory.Build.props into a Rust crate."
+
+[dependencies]

--- a/packages/mbrc-buildinfo/src/lib.rs
+++ b/packages/mbrc-buildinfo/src/lib.rs
@@ -1,0 +1,112 @@
+//! Stamps the product version into a crate at compile time.
+//!
+//! The version is bumped in exactly one place, `Directory.Build.props`
+//! (`<VersionPrefix>`), which the C# assemblies and the CI packaging already
+//! read. Every Rust crate that has to report the product's version reads that
+//! same file through here, so there is never a second place to bump.
+//!
+//! A build script calls [`emit_version`], and the crate reads the result back
+//! with `env!("MBRC_VERSION")`.
+//!
+//! Crate `version` fields in this workspace all stay at 0.1.0. They are
+//! workspace-internal numbers and nothing publishes them.
+
+use std::path::{Path, PathBuf};
+
+/// The props file every version comes from.
+pub const PROPS_FILE: &str = "Directory.Build.props";
+
+/// Emits `MBRC_VERSION` for the calling crate, plus the rerun triggers that keep
+/// it current.
+///
+/// `MBRC_VERSION` in the environment wins when set: CI builds a full version
+/// string that may carry a suffix the props file does not have (nightlies get
+/// `-nightly.<date>`) and passes it down.
+pub fn emit_version() {
+    println!("cargo:rerun-if-env-changed=MBRC_VERSION");
+
+    let version = match std::env::var("MBRC_VERSION") {
+        Ok(v) if !v.trim().is_empty() => v.trim().to_owned(),
+        _ => {
+            let props = find_props();
+            println!("cargo:rerun-if-changed={}", props.display());
+            let xml = std::fs::read_to_string(&props)
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", props.display()));
+            version_prefix(&xml)
+                .unwrap_or_else(|e| panic!("{}: {e}", props.display()))
+                .to_owned()
+        }
+    };
+
+    println!("cargo:rustc-env=MBRC_VERSION={version}");
+}
+
+/// Walks up from the calling crate until it finds the props file.
+///
+/// Searching rather than hard-coding `../..` so moving a crate one level deeper
+/// is not a silent breakage in a build script nobody reads.
+fn find_props() -> PathBuf {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by cargo");
+    let start = Path::new(&manifest_dir);
+    for dir in start.ancestors() {
+        let candidate = dir.join(PROPS_FILE);
+        if candidate.is_file() {
+            return candidate;
+        }
+    }
+    panic!("{PROPS_FILE} not found above {}", start.display());
+}
+
+/// Pulls `<VersionPrefix>x.y.z</VersionPrefix>` out of the props file.
+///
+/// A missing or empty element is a hard error rather than a fallback: a build
+/// that silently reports the wrong version is discovered only after it has
+/// shipped in a release manifest.
+fn version_prefix(xml: &str) -> std::result::Result<&str, String> {
+    const OPEN: &str = "<VersionPrefix>";
+    const CLOSE: &str = "</VersionPrefix>";
+
+    let start = xml.find(OPEN).ok_or_else(|| format!("{OPEN} not found"))? + OPEN.len();
+    let len = xml[start..]
+        .find(CLOSE)
+        .ok_or_else(|| format!("{CLOSE} not found"))?;
+
+    let version = xml[start..start + len].trim();
+    if version.is_empty() {
+        return Err(format!("{OPEN} is empty"));
+    }
+    Ok(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_the_version_prefix() {
+        let xml = "<Project>\n  <PropertyGroup>\n    <VersionPrefix>1.5.0</VersionPrefix>\n  </PropertyGroup>\n</Project>";
+        assert_eq!(version_prefix(xml).unwrap(), "1.5.0");
+    }
+
+    #[test]
+    fn rejects_a_missing_or_empty_element() {
+        assert!(version_prefix("<Project/>").is_err());
+        assert!(version_prefix("<VersionPrefix></VersionPrefix>").is_err());
+        assert!(version_prefix("<VersionPrefix>   </VersionPrefix>").is_err());
+        assert!(version_prefix("<VersionPrefix>1.5.0").is_err());
+    }
+
+    /// The real file, so a malformed props file fails here rather than in a
+    /// build script's panic during a release.
+    #[test]
+    fn the_repository_props_file_carries_a_version() {
+        let props = find_props();
+        let xml = std::fs::read_to_string(&props).unwrap();
+        let version = version_prefix(&xml).unwrap();
+        assert!(
+            version.split('.').count() >= 2,
+            "{version:?} does not look like a version"
+        );
+    }
+}

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -45,10 +45,15 @@ flate2 = { version = "=1.1.9", default-features = false, features = ["rust_backe
 memory-stats = "=1.2.0"
 tokio = { workspace = true }
 mbrc-wire = { workspace = true }
+# The update pipeline: manifest verification plus the check/download/stage half
+# (`client`), which the helper deliberately does not take.
+mbrc-release = { workspace = true, features = ["client"] }
+time = { workspace = true }
 if-addrs = { workspace = true }
 socket2 = "=0.6.4"
 
 [build-dependencies]
+mbrc-buildinfo = { workspace = true }
 csbindgen = "=1.9.8"
 syn = { version = "=2.0.118", features = ["full"] }
 

--- a/packages/mbrc-core/build.rs
+++ b/packages/mbrc-core/build.rs
@@ -9,6 +9,10 @@
 //!
 //! Both outputs are checked in; a CI guard (`git diff --exit-code`) fails if
 //! either drifts from the Rust source.
+//!
+//! It also stamps `MBRC_VERSION` from `Directory.Build.props`, so the core
+//! reports the product's version rather than the crate's workspace-internal
+//! 0.1.0.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -35,6 +39,8 @@ fn main() {
     for f in DTO_SOURCES {
         println!("cargo:rerun-if-changed={f}");
     }
+
+    mbrc_buildinfo::emit_version();
 
     generate_abi_bindings();
     generate_dtos();

--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -4,11 +4,20 @@
 //! This is the single source of truth for runtime config. At cutover the C#
 //! `Configure()` UI edits this file and signals a reload; there is no parallel
 //! C# settings store for these values.
+//!
+//! Preferences only. What the updater has already *done* - when it last checked,
+//! the cached ETag, a version the user skipped - is machine-written state and
+//! lives in `update_state.json` (`mbrc_release::UpdateState`) instead. Mixing the
+//! two would mean a save from the settings panel could quietly un-skip a release.
 
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
+
+/// The release channel the update check follows. The manifest's own `channel`
+/// type, so the setting and the thing it is compared against cannot drift.
+pub use mbrc_release::Channel as UpdateChannel;
 
 fn default_port() -> u16 {
     3000
@@ -86,6 +95,14 @@ fn default_tcp_keepalive_secs() -> u64 {
     45
 }
 
+fn default_update_check_enabled() -> bool {
+    true
+}
+
+fn default_update_check_interval_hours() -> u64 {
+    24
+}
+
 /// The core's runtime configuration. Every field has a default so a missing or
 /// partial `core_settings.json` still yields a usable config.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -150,6 +167,22 @@ pub struct Config {
     /// the kernel detects and drops dead half-open connections.
     #[serde(default = "default_tcp_keepalive_secs")]
     pub tcp_keepalive_secs: u64,
+    /// Whether the core checks for plugin updates at all. A check is a request
+    /// to github.com, so it is a preference, and one the user can turn off.
+    #[serde(default = "default_update_check_enabled")]
+    pub update_check_enabled: bool,
+    /// Which release channel to follow (`stable` / `nightly`).
+    #[serde(default)]
+    pub update_channel: UpdateChannel,
+    /// Hours between automatic checks. The panel's "Check now" ignores it.
+    #[serde(default = "default_update_check_interval_hours")]
+    pub update_check_interval_hours: u64,
+    /// A proxy to use instead of the one Windows detects, as
+    /// `http://host:port`. Empty means automatic detection, which is right
+    /// almost everywhere; this is the escape hatch for the networks where WinHTTP
+    /// guesses wrong and the user would otherwise have no recourse.
+    #[serde(default)]
+    pub proxy_override: String,
     /// The storage directory handed to `mbrc_initialize` (not read from JSON;
     /// set by [`Config::load`]). Roots the on-disk cover cache. Empty in unit
     /// tests that build a `Config` literal - the cover build is skipped then.
@@ -194,6 +227,10 @@ impl Default for Config {
             max_conns_per_client: default_max_conns_per_client(),
             max_conns_per_ip: default_max_conns_per_ip(),
             tcp_keepalive_secs: default_tcp_keepalive_secs(),
+            update_check_enabled: default_update_check_enabled(),
+            update_channel: UpdateChannel::default(),
+            update_check_interval_hours: default_update_check_interval_hours(),
+            proxy_override: String::new(),
             storage_path: String::new(),
         }
     }
@@ -575,6 +612,47 @@ mod tests {
         assert_eq!(c.filter_mode, FilterMode::Range);
         assert_eq!(c.base_ip, "192.168.1.5");
         assert_eq!(c.last_octet_max, 120);
+    }
+
+    #[test]
+    fn update_settings_default_and_round_trip() {
+        // Defaults: checking on, stable, daily, no proxy override.
+        let c = Config::default();
+        assert!(c.update_check_enabled);
+        assert_eq!(c.update_channel, UpdateChannel::Stable);
+        assert_eq!(c.update_check_interval_hours, 24);
+        assert!(c.proxy_override.is_empty());
+
+        let json = serde_json::to_string(&Config {
+            update_check_enabled: false,
+            update_channel: UpdateChannel::Nightly,
+            update_check_interval_hours: 6,
+            proxy_override: "http://proxy.local:8080".into(),
+            ..Config::default()
+        })
+        .unwrap();
+        assert!(json.contains("\"update_channel\":\"nightly\""), "{json}");
+
+        let back: Config = serde_json::from_str(&json).unwrap();
+        assert!(!back.update_check_enabled);
+        assert_eq!(back.update_channel, UpdateChannel::Nightly);
+        assert_eq!(back.update_check_interval_hours, 6);
+        assert_eq!(back.proxy_override, "http://proxy.local:8080");
+
+        // Nothing the updater writes for itself belongs in here; that state
+        // lives in update_state.json.
+        assert!(!json.contains("last_check"), "{json}");
+        assert!(!json.contains("skipped_version"), "{json}");
+        assert!(!json.contains("etag"), "{json}");
+    }
+
+    #[test]
+    fn an_older_settings_file_gains_the_update_defaults() {
+        // A file written before these fields existed must keep working, with
+        // checking on rather than silently off.
+        let c: Config = serde_json::from_str(r#"{"port":3000}"#).unwrap();
+        assert!(c.update_check_enabled);
+        assert_eq!(c.update_channel, UpdateChannel::Stable);
     }
 
     #[test]

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod providers;
 pub mod server;
 pub mod state;
 pub mod store;
+pub mod updates;
 pub mod wire;
 
 use std::ffi::{c_char, c_int, CStr, CString};

--- a/packages/mbrc-core/src/updates.rs
+++ b/packages/mbrc-core/src/updates.rs
@@ -1,0 +1,157 @@
+//! The core's side of the update pipeline: settings in, staged update out.
+//!
+//! The decisions all live in `mbrc-release` (`check`, `stage`, `UpdateState`).
+//! What is here is the plumbing that crate deliberately does not know about: the
+//! user's preferences, the storage directory, and the version the running plugin
+//! reports over FFI.
+//!
+//! Nothing here reaches the network on its own. It takes an
+//! [`HttpClient`](mbrc_release::HttpClient), whose one production implementation
+//! (WinHTTP) arrives with the Windows half of this work; the panel and the
+//! background schedule that call in arrive with the UI (#152).
+
+use mbrc_release::{
+    check::{self, CheckOptions, CheckOutcome},
+    stage, AvailableUpdate, HttpClient, Result, StagedUpdate, UpdateState,
+};
+use time::OffsetDateTime;
+
+use crate::config::Config;
+
+/// The product version this core was built as, from `Directory.Build.props`.
+/// The update check compares against the version the *plugin* reports over FFI;
+/// this is what the core says about itself in the log.
+pub const CORE_VERSION: &str = env!("MBRC_VERSION");
+
+/// Runs a check according to the user's settings, persisting what it learns.
+///
+/// `plugin_version` is what `QueryType::PluginVersion` returned - a .NET
+/// four-component string, which the comparison normalizes.
+///
+/// The state file is written on the way out whatever the outcome, including
+/// after a failure: that is what makes the backoff work.
+pub fn check_for_update(
+    client: &dyn HttpClient,
+    config: &Config,
+    plugin_version: &str,
+    force: bool,
+) -> Result<CheckOutcome> {
+    if !config.update_check_enabled && !force {
+        return Ok(CheckOutcome::Disabled);
+    }
+
+    let mut state = load_state(&config.storage_path);
+    let options = check_options(config, plugin_version, force);
+    let outcome = check::check(client, &options, &mut state, OffsetDateTime::now_utc());
+
+    if let Err(e) = state.save(&config.storage_path) {
+        // Not fatal: it costs an early re-check, and losing the check is worse
+        // than losing the record of it.
+        tracing::warn!(error = %e, "could not persist update state");
+    }
+
+    match &outcome {
+        Ok(o) => tracing::info!(outcome = ?o, "update check finished"),
+        Err(e) => tracing::warn!(error = %e, "update check failed"),
+    }
+    outcome
+}
+
+/// Downloads and stages a verified update under the storage directory. See
+/// [`mbrc_release::stage`] for what staging is and is not allowed to touch.
+pub fn stage_update(
+    client: &dyn HttpClient,
+    config: &Config,
+    update: &AvailableUpdate,
+) -> Result<StagedUpdate> {
+    let staged = stage::stage(
+        client,
+        update,
+        &config.storage_path,
+        OffsetDateTime::now_utc(),
+    )?;
+    tracing::info!(
+        version = %staged.version,
+        files = staged.files.len(),
+        "staged an update for the next restart"
+    );
+    Ok(staged)
+}
+
+/// Records that the user does not want to be offered `version` again.
+pub fn skip_version(config: &Config, version: &str) -> Result<()> {
+    let mut state = load_state(&config.storage_path);
+    state.skipped_version = Some(version.to_owned());
+    state.save(&config.storage_path)
+}
+
+/// Builds the check inputs from the user's settings.
+fn check_options<'a>(config: &Config, plugin_version: &'a str, force: bool) -> CheckOptions<'a> {
+    CheckOptions {
+        interval_hours: config.update_check_interval_hours,
+        force,
+        ..CheckOptions::new(plugin_version, config.update_channel)
+    }
+}
+
+/// Reads the state file, logging (and then ignoring) a corrupt one: a bad state
+/// file must not be able to stop the plugin checking for updates ever again.
+fn load_state(storage_path: &str) -> UpdateState {
+    match UpdateState::load_checked(storage_path) {
+        Ok(state) => state,
+        Err(e) => {
+            tracing::warn!(error = %e, "update state is unreadable; starting fresh");
+            UpdateState::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mbrc_release::Channel;
+
+    #[test]
+    fn the_core_version_is_the_product_version() {
+        // Not the crate's workspace-internal 0.1.0.
+        assert_ne!(CORE_VERSION, "0.1.0");
+        assert!(
+            CORE_VERSION.split('.').count() >= 2,
+            "{CORE_VERSION:?} does not look like a version"
+        );
+    }
+
+    #[test]
+    fn options_come_from_the_settings() {
+        let config = Config {
+            update_channel: Channel::Nightly,
+            update_check_interval_hours: 6,
+            ..Config::default()
+        };
+        let options = check_options(&config, "1.5.0.0", false);
+        assert_eq!(options.current_version, "1.5.0.0");
+        assert_eq!(options.channel, Channel::Nightly);
+        assert_eq!(options.interval_hours, 6);
+        assert!(!options.force);
+        assert_eq!(options.repo, check::DEFAULT_REPO);
+        // The compiled-in release keys, not an empty or test trust list.
+        assert!(!options.keys.is_empty());
+    }
+
+    #[test]
+    fn a_disabled_check_does_not_go_near_the_network() {
+        struct NeverCalled;
+        impl HttpClient for NeverCalled {
+            fn get(&self, _url: &str, _etag: Option<&str>) -> Result<mbrc_release::HttpResponse> {
+                panic!("a disabled check must not make a request");
+            }
+        }
+
+        let config = Config {
+            update_check_enabled: false,
+            ..Config::default()
+        };
+        let outcome = check_for_update(&NeverCalled, &config, "1.5.0.0", false).unwrap();
+        assert!(matches!(outcome, CheckOutcome::Disabled), "{outcome:?}");
+    }
+}

--- a/packages/mbrc-helper/Cargo.toml
+++ b/packages/mbrc-helper/Cargo.toml
@@ -10,7 +10,18 @@ name = "mbrc-helper"
 path = "src/main.rs"
 
 [dependencies]
+# Without the `client` feature: the helper verifies manifests and applies staged
+# files, so it has no use for the HTTP/check/stage half. The workspace
+# declaration turns the default features off and the core opts back in.
+#
+# Cargo unifies features per build, so a single `cargo build -p mbrc-core -p
+# mbrc-helper` still compiles one mbrc-release with `client` on for both. What
+# this buys is the dependency edge: nothing the helper calls can reach into that
+# half, and building the helper on its own does not pull semver/zip/time in.
 mbrc-release.workspace = true
+
+[build-dependencies]
+mbrc-buildinfo.workspace = true
 
 # COM interface wrappers (INetFwPolicy2/INetFwRule) exist only in `windows`, not
 # in `windows-sys`, which is why this crate takes the heavier of the two.

--- a/packages/mbrc-helper/build.rs
+++ b/packages/mbrc-helper/build.rs
@@ -2,57 +2,9 @@
 //!
 //! The helper ships in the release bundle next to the two DLLs and is listed in
 //! the update manifest, so it has to report the same version as the rest of the
-//! product. That version is bumped in exactly one place, `Directory.Build.props`
-//! (`<VersionPrefix>`), which the C# assemblies and the CI packaging already
-//! read. This reads the same file rather than adding a second place to bump.
-//!
-//! `MBRC_VERSION` in the environment wins when set: CI builds a full version
-//! string that may carry a suffix the props file does not have (nightlies get
-//! `-nightly.<date>`), and passes it down.
-//!
-//! The crate's own `version` in Cargo.toml stays at 0.1.0 like every other crate
-//! in this workspace. It is a workspace-internal number and is never published.
-
-use std::path::Path;
+//! product. `mbrc-buildinfo` reads it from `Directory.Build.props`, the one place
+//! the version is bumped.
 
 fn main() {
-    let props = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../Directory.Build.props");
-    println!("cargo:rerun-if-env-changed=MBRC_VERSION");
-    println!("cargo:rerun-if-changed={}", props.display());
-
-    let version = match std::env::var("MBRC_VERSION") {
-        Ok(v) if !v.trim().is_empty() => v.trim().to_string(),
-        _ => read_version_prefix(&props),
-    };
-
-    println!("cargo:rustc-env=MBRC_VERSION={version}");
-}
-
-/// Pulls `<VersionPrefix>x.y.z</VersionPrefix>` out of the props file.
-///
-/// A missing or malformed file is a hard error rather than a fallback: a helper
-/// that silently reports the wrong version would be discovered only after it had
-/// shipped in a manifest.
-fn read_version_prefix(props: &Path) -> String {
-    let xml = std::fs::read_to_string(props)
-        .unwrap_or_else(|e| panic!("cannot read {}: {e}", props.display()));
-
-    const OPEN: &str = "<VersionPrefix>";
-    const CLOSE: &str = "</VersionPrefix>";
-
-    let start = xml
-        .find(OPEN)
-        .unwrap_or_else(|| panic!("{OPEN} not found in {}", props.display()))
-        + OPEN.len();
-    let len = xml[start..]
-        .find(CLOSE)
-        .unwrap_or_else(|| panic!("{CLOSE} not found in {}", props.display()));
-
-    let version = xml[start..start + len].trim().to_string();
-    assert!(
-        !version.is_empty(),
-        "{OPEN} is empty in {}",
-        props.display()
-    );
-    version
+    mbrc_buildinfo::emit_version();
 }

--- a/packages/mbrc-release/Cargo.toml
+++ b/packages/mbrc-release/Cargo.toml
@@ -5,11 +5,43 @@ edition.workspace = true
 authors.workspace = true
 description = "Signed release manifest parsing and verification shared by the core and the updater."
 
+[features]
+# The check/download/stage half. On by default so the crate tests itself in
+# full; `mbrc-helper` takes the crate without it, because an elevated exe should
+# carry the manifest verifier and nothing else.
+default = ["client"]
+client = ["dep:semver", "dep:zip", "dep:flate2", "dep:time"]
+
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
 # Zero-dependency Ed25519 minisign verification. The signing half never lives
 # here: releases are signed in CI with the `minisign` CLI.
 minisign-verify = "=0.2.5"
+sha2 = "=0.10.9"
+hex = "=0.4.3"
+
+# Version comparison. Zero dependencies (std only, serde opted out), and it is
+# Cargo's own implementation: prerelease precedence is a well known source of
+# subtle bugs and not somewhere to hand-roll, least of all in the component that
+# decides whether to replace a DLL.
+semver = { version = "=1.0.28", optional = true }
+# Reading the update zip. `deflate-flate2` and NOT `deflate`: the latter pulls in
+# zopfli, a *compressor*, and this crate only ever decompresses. flate2 rides on
+# pure-Rust miniz_oxide, so the i686 target stays free of a C toolchain.
+zip = { version = "=8.6.0", default-features = false, features = ["deflate-flate2"], optional = true }
+# `deflate-flate2` selects flate2 but no backend, so the backend is chosen here:
+# miniz_oxide, the same pure-Rust one mbrc-core already uses for its log gzip. No
+# C toolchain, and one decompressor in the workspace rather than two.
+flate2 = { version = "=1.1.9", default-features = false, features = ["rust_backend"], optional = true }
+# Timestamps for the check interval and the staging marker.
+time = { workspace = true, features = ["parsing"], optional = true }
+
+# Integration tests build their own archives and hashes: a crate's own
+# dependencies are not in scope for `tests/`, so the ones they use directly are
+# repeated here.
+[dev-dependencies]
+time = { workspace = true, features = ["parsing"] }
+zip = { version = "=8.6.0", default-features = false, features = ["deflate-flate2"] }
 sha2 = "=0.10.9"
 hex = "=0.4.3"

--- a/packages/mbrc-release/src/check.rs
+++ b/packages/mbrc-release/src/check.rs
@@ -1,0 +1,239 @@
+//! Deciding whether there is an update worth offering.
+//!
+//! The order matters and is the same every time: fetch the release document,
+//! verify the manifest's signature, *then* look at the version. Nothing decides
+//! anything on unverified bytes, and nothing is downloaded on the strength of a
+//! version number alone.
+//!
+//! Everything here is above the [`HttpClient`] seam, so `tests/check_tests.rs`
+//! drives the whole thing against a stub on any host.
+
+use serde::Deserialize;
+use time::OffsetDateTime;
+
+use crate::{
+    error::{Result, UpdateError},
+    http::HttpClient,
+    manifest::{Channel, Manifest},
+    state::UpdateState,
+    verify::{verify_manifest_with, TrustedKey, TRUSTED_KEYS},
+    version,
+};
+
+/// The repository releases are published to.
+pub const DEFAULT_REPO: &str = "musicbeeremote/mbrc-plugin";
+
+/// Asset names every release carries, written by the packaging workflow.
+pub const MANIFEST_ASSET: &str = "manifest.json";
+pub const SIGNATURE_ASSET: &str = "manifest.json.minisig";
+
+/// The rolling tag the nightly channel tracks (#148).
+const NIGHTLY_TAG: &str = "nightly";
+
+/// What the caller wants checked. Assembled from `Config` by the core; kept as a
+/// parameter object so the check itself stays a pure function of its inputs.
+#[derive(Debug, Clone)]
+pub struct CheckOptions<'a> {
+    /// The running plugin's version, as reported over FFI. Four-component .NET
+    /// strings are fine - [`version::parse`] normalizes them.
+    pub current_version: &'a str,
+    pub channel: Channel,
+    pub interval_hours: u64,
+    /// `owner/name`; a parameter so tests never touch the real repository.
+    pub repo: &'a str,
+    /// The user pressed "Check now": ignore the interval, but nothing else.
+    pub force: bool,
+    /// The keys a manifest may be signed with. Defaults to the compiled-in
+    /// release keys; explicit so the trust list is a visible input rather than an
+    /// ambient global, matching [`crate::verify::verify_signature_with`].
+    pub keys: &'static [TrustedKey],
+}
+
+impl<'a> CheckOptions<'a> {
+    pub fn new(current_version: &'a str, channel: Channel) -> Self {
+        Self {
+            current_version,
+            channel,
+            interval_hours: 24,
+            repo: DEFAULT_REPO,
+            force: false,
+            keys: TRUSTED_KEYS,
+        }
+    }
+
+    /// The GitHub API endpoint for the channel. Stable follows `releases/latest`,
+    /// which GitHub resolves to the newest non-prerelease; nightly is a fixed
+    /// rolling tag, which cannot be reached that way.
+    pub fn endpoint(&self) -> String {
+        let repo = self.repo;
+        match self.channel {
+            Channel::Stable => format!("https://api.github.com/repos/{repo}/releases/latest"),
+            Channel::Nightly => {
+                format!("https://api.github.com/repos/{repo}/releases/tags/{NIGHTLY_TAG}")
+            }
+        }
+    }
+}
+
+/// A verified update the user can be offered.
+#[derive(Debug, Clone)]
+pub struct AvailableUpdate {
+    pub manifest: Manifest,
+    /// The manifest exactly as it was signed. Kept byte-for-byte rather than
+    /// re-serialized from `manifest`, because a re-serialized copy is a different
+    /// document as far as the signature is concerned.
+    pub manifest_bytes: Vec<u8>,
+    /// The detached signature, carried through to staging so the helper can
+    /// re-verify at apply time from the staged copy rather than trusting us.
+    pub signature: String,
+    /// Download URL of the zip named by `manifest.artifacts.zip`.
+    pub zip_url: String,
+    /// Which trusted key verified the manifest, for the log line.
+    pub key_name: &'static str,
+}
+
+/// Which update a check produced, or why it produced none.
+#[derive(Debug, Clone)]
+pub enum CheckOutcome {
+    /// The user turned update checks off. Produced by the caller that owns the
+    /// setting, not by [`check`] itself.
+    Disabled,
+    /// The interval has not elapsed and the caller did not force a check.
+    NotDue,
+    /// The release document is unchanged since the cached `ETag`. Nothing was
+    /// downloaded and nothing re-verified.
+    NotModified,
+    /// The published release is not newer than what is running.
+    UpToDate {
+        latest: String,
+    },
+    /// Newer, but the user asked to skip exactly this version.
+    Skipped {
+        version: String,
+    },
+    Available(Box<AvailableUpdate>),
+}
+
+/// Runs a check, updating `state` with the outcome. The caller persists `state`
+/// (including after an error, so a failing check backs off instead of retrying on
+/// every tick) and decides what to do with the result.
+///
+/// Note what is deliberately *not* gated here: the manifest's `abi_version` and
+/// `min_musicbee_build`. A bundle ships `mb_remote.dll` and `mbrc_core.dll`
+/// together, so its ABI is internally consistent by construction, and refusing an
+/// update because it bumped the ABI would block exactly the updates that need to
+/// ship. The MusicBee build gate belongs where the MusicBee version is known,
+/// which is the panel (#152), not here.
+pub fn check(
+    client: &dyn HttpClient,
+    options: &CheckOptions<'_>,
+    state: &mut UpdateState,
+    now: OffsetDateTime,
+) -> Result<CheckOutcome> {
+    if !options.force && !state.is_due(now, options.interval_hours) {
+        return Ok(CheckOutcome::NotDue);
+    }
+
+    match run(client, options, state, now) {
+        Ok(outcome) => {
+            state.clear_failures();
+            Ok(outcome)
+        }
+        Err(e) => {
+            state.record_failure(now);
+            Err(e)
+        }
+    }
+}
+
+fn run(
+    client: &dyn HttpClient,
+    options: &CheckOptions<'_>,
+    state: &mut UpdateState,
+    now: OffsetDateTime,
+) -> Result<CheckOutcome> {
+    let current = version::parse(options.current_version)?;
+
+    let endpoint = options.endpoint();
+    let response = client.get(&endpoint, state.etag.as_deref())?;
+    if response.is_not_modified() {
+        state.record_check(now, None);
+        return Ok(CheckOutcome::NotModified);
+    }
+    let etag = response.etag.clone();
+    let release: Release = serde_json::from_slice(&response.into_body(&endpoint)?)
+        .map_err(|e| UpdateError::Parse(format!("release document: {e}")))?;
+
+    // Signature first: the manifest's claims are worth nothing until it has been
+    // shown to come from a release key.
+    let manifest_url = release.asset_url(MANIFEST_ASSET)?.to_owned();
+    let signature_url = release.asset_url(SIGNATURE_ASSET)?.to_owned();
+    let manifest_bytes = client.get(&manifest_url, None)?.into_body(&manifest_url)?;
+    let signature = String::from_utf8(
+        client
+            .get(&signature_url, None)?
+            .into_body(&signature_url)?,
+    )
+    .map_err(|e| UpdateError::MalformedSignature(e.to_string()))?;
+    let (manifest, key_name) = verify_manifest_with(&manifest_bytes, &signature, options.keys)?;
+
+    // A manifest from the wrong channel means the tag and its assets disagree.
+    // Nightly and stable carry different expectations, so this is refused rather
+    // than quietly accepted.
+    if manifest.channel != options.channel {
+        return Err(UpdateError::Invalid(format!(
+            "{endpoint} carries a {:?} manifest but the {:?} channel was checked",
+            manifest.channel, options.channel
+        )));
+    }
+
+    let zip_url = release.asset_url(&manifest.artifacts.zip.name)?.to_owned();
+    let latest = version::parse(&manifest.version)?;
+
+    // Only reaching here counts as a check; the interval starts now whatever the
+    // verdict below turns out to be.
+    state.record_check(now, etag);
+
+    if latest <= current {
+        return Ok(CheckOutcome::UpToDate {
+            latest: manifest.version,
+        });
+    }
+    if state.is_skipped(&manifest.version) {
+        return Ok(CheckOutcome::Skipped {
+            version: manifest.version,
+        });
+    }
+
+    Ok(CheckOutcome::Available(Box::new(AvailableUpdate {
+        manifest,
+        manifest_bytes,
+        signature,
+        zip_url,
+        key_name,
+    })))
+}
+
+/// The subset of GitHub's release document the updater reads. Unknown fields are
+/// ignored: this is somebody else's schema and it grows.
+#[derive(Debug, Deserialize)]
+struct Release {
+    #[serde(default)]
+    assets: Vec<Asset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Asset {
+    name: String,
+    browser_download_url: String,
+}
+
+impl Release {
+    fn asset_url(&self, name: &str) -> Result<&str> {
+        self.assets
+            .iter()
+            .find(|a| a.name == name)
+            .map(|a| a.browser_download_url.as_str())
+            .ok_or_else(|| UpdateError::Invalid(format!("the release has no asset named {name:?}")))
+    }
+}

--- a/packages/mbrc-release/src/error.rs
+++ b/packages/mbrc-release/src/error.rs
@@ -21,6 +21,23 @@ pub enum UpdateError {
         expected: String,
         actual: String,
     },
+    /// A version string could not be normalized to comparable semver.
+    Version(String),
+    /// The request never produced a response (DNS, TLS, proxy, timeout).
+    Network(String),
+    /// The server answered, but not with something usable.
+    Http { status: u16, url: String },
+    /// A local file operation failed while staging.
+    Io(String),
+    /// The downloaded zip could not be read as one.
+    Archive(String),
+    /// The zip carries an entry whose name is not a bare filename. The whole
+    /// bundle is refused rather than the entry skipped: a release built by CI
+    /// never contains one, so its presence means the archive is not what the
+    /// manifest describes.
+    UnsafeEntry(String),
+    /// The manifest lists a file the zip does not contain.
+    MissingEntry(String),
 }
 
 impl fmt::Display for UpdateError {
@@ -49,6 +66,19 @@ impl fmt::Display for UpdateError {
             } => write!(
                 f,
                 "sha512 mismatch for {path}: manifest says {expected}, file is {actual}"
+            ),
+            Self::Version(m) => write!(f, "cannot read version: {m}"),
+            Self::Network(m) => write!(f, "request failed: {m}"),
+            Self::Http { status, url } => write!(f, "HTTP {status} from {url}"),
+            Self::Io(m) => write!(f, "staging failed: {m}"),
+            Self::Archive(m) => write!(f, "update archive is not readable: {m}"),
+            Self::UnsafeEntry(name) => write!(
+                f,
+                "update archive contains {name:?}, which is not a bare filename"
+            ),
+            Self::MissingEntry(name) => write!(
+                f,
+                "update archive is missing {name:?}, which the manifest lists"
             ),
         }
     }

--- a/packages/mbrc-release/src/http.rs
+++ b/packages/mbrc-release/src/http.rs
@@ -1,0 +1,90 @@
+//! The one seam between the update logic and the network.
+//!
+//! The production client is WinHTTP (system proxy including PAC/WPAD, OS root
+//! certificates, no new build tooling for the i686 target - see `docs/updates.md`),
+//! which cannot be exercised from a non-Windows host. Everything interesting -
+//! version comparison, ETag caching, interval and skip-version suppression,
+//! signature verification, staging - sits above this trait and is tested against
+//! a stub, so exactly one thin implementation is Windows-bound.
+
+use crate::error::{Result, UpdateError};
+
+/// What a `GET` produced. Only the pieces the updater acts on: the rest of an
+/// HTTP response is not this crate's business.
+#[derive(Debug, Clone)]
+pub struct HttpResponse {
+    pub status: u16,
+    /// The response `ETag`, stored and sent back as `If-None-Match` so a repeat
+    /// check that changes nothing costs one 304 instead of a download.
+    pub etag: Option<String>,
+    pub body: Vec<u8>,
+}
+
+/// Not modified since the caller's `ETag`.
+pub const STATUS_NOT_MODIFIED: u16 = 304;
+
+impl HttpResponse {
+    pub fn is_not_modified(&self) -> bool {
+        self.status == STATUS_NOT_MODIFIED
+    }
+
+    pub fn is_success(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    /// The body, or an error for any status that is not a success.
+    ///
+    /// A 304 is an error here too: it is meaningful only where the caller asked
+    /// for it, and those call sites check [`is_not_modified`](Self::is_not_modified)
+    /// first. Reaching this with one means a conditional request was made
+    /// somewhere that cannot handle the conditional answer.
+    pub fn into_body(self, url: &str) -> Result<Vec<u8>> {
+        if self.is_success() {
+            Ok(self.body)
+        } else {
+            Err(UpdateError::Http {
+                status: self.status,
+                url: url.to_owned(),
+            })
+        }
+    }
+}
+
+/// A blocking HTTP GET.
+///
+/// Deliberately the whole interface. The updater only ever reads: it fetches a
+/// release document, a manifest, a signature, and a zip. Anything richer would be
+/// surface that the WinHTTP implementation has to carry for no caller.
+pub trait HttpClient {
+    /// Issues `GET url`. When `etag` is set it is sent as `If-None-Match`, and a
+    /// `304` is a normal, non-error outcome the caller is expected to handle.
+    fn get(&self, url: &str, etag: Option<&str>) -> Result<HttpResponse>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn into_body_rejects_failure_statuses() {
+        let response = HttpResponse {
+            status: 404,
+            etag: None,
+            body: b"nope".to_vec(),
+        };
+        assert!(matches!(
+            response.into_body("https://example.invalid/x"),
+            Err(UpdateError::Http { status: 404, .. })
+        ));
+    }
+
+    #[test]
+    fn into_body_rejects_an_unexpected_304() {
+        let response = HttpResponse {
+            status: STATUS_NOT_MODIFIED,
+            etag: None,
+            body: Vec::new(),
+        };
+        assert!(response.into_body("https://example.invalid/x").is_err());
+    }
+}

--- a/packages/mbrc-release/src/lib.rs
+++ b/packages/mbrc-release/src/lib.rs
@@ -1,4 +1,4 @@
-//! Signed release manifest parsing and verification.
+//! Release manifests, and the update check that acts on them.
 //!
 //! Shared by the Rust core, which checks and stages updates, and by
 //! `mbrc-helper`, which applies them. Both use the same manifest schema and the
@@ -7,14 +7,48 @@
 //!
 //! The signing half deliberately lives nowhere in this crate: releases are
 //! signed in CI with the `minisign` CLI, and only public keys are compiled in.
+//!
+//! # Layout
+//!
+//! - [`manifest`] / [`verify`] - the schema and its signature. Always compiled.
+//! - [`check`] / [`stage`] / [`state`] / [`http`] / [`version`] - deciding there
+//!   is an update and putting it somewhere the helper can find it. Behind the
+//!   `client` feature, which is on by default but off for the helper: an
+//!   elevated process should carry as little as it can get away with.
+//!
+//! Everything in the client half sits above the [`http::HttpClient`] trait, so
+//! all of it is tested against a stub on any host. Only the WinHTTP
+//! implementation of that one trait is Windows-bound.
 
 pub mod error;
 pub mod manifest;
 pub mod verify;
 
+#[cfg(feature = "client")]
+pub mod check;
+#[cfg(feature = "client")]
+pub mod http;
+#[cfg(feature = "client")]
+pub mod stage;
+#[cfg(feature = "client")]
+pub mod state;
+#[cfg(feature = "client")]
+pub mod version;
+
 pub use error::{Result, UpdateError};
-pub use manifest::{Artifact, Artifacts, Channel, FileEntry, Manifest, SCHEMA_VERSION};
-pub use verify::{
-    verify_bundled_file, verify_manifest, verify_sha512, verify_signature, verify_signature_with,
-    TrustedKey, TRUSTED_KEYS,
+pub use manifest::{
+    is_bare_filename, Artifact, Artifacts, Channel, FileEntry, Manifest, SCHEMA_VERSION,
 };
+pub use verify::{
+    verify_bundled_file, verify_manifest, verify_manifest_with, verify_sha512, verify_signature,
+    verify_signature_with, TrustedKey, TRUSTED_KEYS,
+};
+
+#[cfg(feature = "client")]
+pub use check::{check, AvailableUpdate, CheckOptions, CheckOutcome};
+#[cfg(feature = "client")]
+pub use http::{HttpClient, HttpResponse};
+#[cfg(feature = "client")]
+pub use stage::{clear_staged, read_pending, stage, Pending, StagedUpdate};
+#[cfg(feature = "client")]
+pub use state::UpdateState;

--- a/packages/mbrc-release/src/manifest.rs
+++ b/packages/mbrc-release/src/manifest.rs
@@ -15,10 +15,13 @@ pub const SCHEMA_VERSION: u32 = 1;
 /// Length of a hex-encoded SHA512 digest.
 const SHA512_HEX_LEN: usize = 128;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Channel {
+    /// Released versions. The default: nobody ends up on nightlies by omission.
+    #[default]
     Stable,
+    /// The rolling `nightly` tag (#148).
     Nightly,
 }
 
@@ -138,20 +141,53 @@ fn check_hash(hash: &str, field: &str) -> Result<()> {
 ///
 /// This is the zip-slip guard, enforced at parse time rather than at extraction
 /// time so no caller can forget it. Path separators, drive letters, and `..` all
-/// escape the target directory, and the updater writes as an elevated process.
+/// escape the target directory, and the files this names are later written by an
+/// elevated process.
 fn check_filename(name: &str, field: &str) -> Result<()> {
-    let bad = name.is_empty()
-        || name.contains('/')
-        || name.contains('\\')
-        || name.contains(':')
-        || name == "."
-        || name == ".."
-        || name.starts_with('.');
-
-    if bad {
+    if !is_bare_filename(name) {
         return Err(UpdateError::Invalid(format!(
             "{field}: {name:?} is not a bare filename"
         )));
     }
     Ok(())
+}
+
+/// Windows treats these as device names in any directory, extension or not, so
+/// `NUL` and `nul.dll` both address a device rather than a file.
+const RESERVED_DEVICE_NAMES: &[&str] = &[
+    "con", "prn", "aux", "nul", "com1", "com2", "com3", "com4", "com5", "com6", "com7", "com8",
+    "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7", "lpt8", "lpt9",
+];
+
+/// Whether `name` is a plain filename that can only ever resolve inside the
+/// directory it is joined to.
+///
+/// Shared by the manifest parser and the staging extractor, so the one rule that
+/// keeps an update from writing outside its own directory has one definition. It
+/// is deliberately a allowlist-shaped rejection list rather than a
+/// canonicalize-and-compare: this has to hold for names that do not exist on disk
+/// yet, on a machine whose filesystem semantics we are not the ones deciding.
+pub fn is_bare_filename(name: &str) -> bool {
+    if name.is_empty() || name == "." || name == ".." {
+        return false;
+    }
+    // A leading dot hides the file on the platforms that care and buys nothing
+    // here; a trailing dot or space is silently stripped by Windows, so
+    // `mb_remote.dll.` and `mb_remote.dll` would name the same file.
+    if name.starts_with('.') || name.ends_with('.') || name.ends_with(' ') {
+        return false;
+    }
+    // Separators and drive letters escape the directory outright. The rest are
+    // characters Windows refuses in a filename, and control characters, which
+    // exist in a name only to make a log line lie about what was written.
+    if name.chars().any(|c| {
+        matches!(c, '/' | '\\' | ':' | '<' | '>' | '"' | '|' | '?' | '*') || c.is_control()
+    }) {
+        return false;
+    }
+
+    let stem = name.split('.').next().unwrap_or(name);
+    !RESERVED_DEVICE_NAMES
+        .iter()
+        .any(|reserved| stem.eq_ignore_ascii_case(reserved))
 }

--- a/packages/mbrc-release/src/stage.rs
+++ b/packages/mbrc-release/src/stage.rs
@@ -1,0 +1,275 @@
+//! Downloading a verified update and laying it out for the helper to apply.
+//!
+//! # What this is allowed to touch
+//!
+//! Staging runs unelevated, but everything it writes is later read by a process
+//! running as administrator, so the boundaries are part of the design rather than
+//! an implementation detail:
+//!
+//! - **One directory, derived not supplied.** Everything lands under
+//!   `<storage>/updates/<version>/`, where `<storage>` is the directory MusicBee
+//!   handed the core at init. No caller passes a destination path in, and no
+//!   value out of the archive or the manifest ever contributes a path segment
+//!   that has not been checked to be a bare filename
+//!   ([`crate::manifest::is_bare_filename`]).
+//! - **Nothing is followed.** The staging root and the per-version directory are
+//!   refused if they exist as symlinks or junctions. Otherwise anyone who can
+//!   create a reparse point in `%APPDATA%` could aim an unelevated write, and
+//!   later an elevated copy, at a directory neither of us chose.
+//! - **`pending.json` holds no paths.** It names a version, and the helper joins
+//!   that to a storage directory it derives for itself (#151). An elevated
+//!   process must never be handed a path by an unelevated one.
+//! - **Staging-time verification is not apply-time verification.** These files
+//!   sit somewhere a non-elevated process can write, so the helper re-verifies
+//!   from the staged `manifest.json` + `.minisig` before it copies anything. That
+//!   is why both are staged alongside the payload.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::{
+    check::{AvailableUpdate, MANIFEST_ASSET, SIGNATURE_ASSET},
+    error::{Result, UpdateError},
+    http::HttpClient,
+    manifest::{is_bare_filename, Manifest},
+    verify::verify_sha512,
+};
+
+/// Staging root under the core's storage directory. Inside
+/// `%APPDATA%\MusicBee\mb_remote`, which the NSIS uninstaller already removes
+/// wholesale, so a staged update never outlives the plugin.
+pub const STAGING_DIR: &str = "updates";
+
+/// The commit marker. Written last, so its presence means every file in the
+/// directory has been extracted and verified.
+pub const PENDING_FILE: &str = "pending.json";
+
+/// Schema of [`Pending`]; the helper refuses anything else (#151).
+pub const PENDING_SCHEMA: u32 = 1;
+
+/// What the helper reads to find out there is something to apply.
+///
+/// Note what is absent: any path. The helper derives the storage directory
+/// itself and joins [`STAGING_DIR`] and `version` to it, so a tampered
+/// `pending.json` can name a directory that does not exist but cannot name one
+/// outside the staging root.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Pending {
+    pub schema: u32,
+    /// The staged version, and the name of its directory under [`STAGING_DIR`].
+    /// Always a bare filename; the helper re-checks before joining it.
+    pub version: String,
+    pub staged_at: String,
+    /// The staged payload filenames, for logging and for the panel. Not the
+    /// authority on what gets applied: that is the staged manifest, which is
+    /// signed.
+    pub files: Vec<String>,
+}
+
+/// Where a staged update ended up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagedUpdate {
+    pub dir: PathBuf,
+    pub version: String,
+    pub files: Vec<String>,
+}
+
+/// Downloads the zip named by the verified manifest, extracts exactly the files
+/// the manifest lists, and writes [`PENDING_FILE`] once every one of them has
+/// verified.
+///
+/// The archive is held in memory and never written to disk as a whole: a
+/// half-extracted, unverified zip lying next to the staged files is one more
+/// thing that has to be reasoned about.
+pub fn stage(
+    client: &dyn HttpClient,
+    update: &AvailableUpdate,
+    storage_dir: &str,
+    now: OffsetDateTime,
+) -> Result<StagedUpdate> {
+    let manifest = &update.manifest;
+    let version = &manifest.version;
+    if !is_bare_filename(version) {
+        return Err(UpdateError::Invalid(format!(
+            "version {version:?} cannot be a directory name"
+        )));
+    }
+
+    let root = Path::new(storage_dir).join(STAGING_DIR);
+    let dir = root.join(version);
+    prepare_dir(&root)?;
+    // A previous attempt may have left a partial directory. It is ours and it is
+    // named after this exact version, so it is replaced rather than merged with.
+    if dir.exists() {
+        refuse_reparse_point(&dir)?;
+        std::fs::remove_dir_all(&dir).map_err(|e| io(&dir, e))?;
+    }
+
+    let payload = download_zip(client, update)?;
+    let files = extract_verified(&payload, manifest)?;
+
+    std::fs::create_dir_all(&dir).map_err(|e| io(&dir, e))?;
+    for (name, bytes) in &files {
+        write_file(&dir.join(name), bytes)?;
+    }
+    // The signed manifest and its signature travel with the payload so the
+    // elevated apply re-verifies from these, not from anything we tell it.
+    write_file(&dir.join(MANIFEST_ASSET), &update.manifest_bytes)?;
+    write_file(&dir.join(SIGNATURE_ASSET), update.signature.as_bytes())?;
+
+    let names: Vec<String> = files.into_iter().map(|(name, _)| name).collect();
+    let pending = Pending {
+        schema: PENDING_SCHEMA,
+        version: version.clone(),
+        staged_at: now.format(&Rfc3339).unwrap_or_default(),
+        files: names.clone(),
+    };
+    let json = serde_json::to_string_pretty(&pending)
+        .map_err(|e| UpdateError::Io(format!("serialize {PENDING_FILE}: {e}")))?;
+    write_file(&root.join(PENDING_FILE), json.as_bytes())?;
+
+    Ok(StagedUpdate {
+        dir,
+        version: version.clone(),
+        files: names,
+    })
+}
+
+/// Reads [`PENDING_FILE`], if there is one. A corrupt or unknown-schema marker is
+/// an error rather than "nothing staged": something wrote it, and silently
+/// ignoring it would hide that.
+pub fn read_pending(storage_dir: &str) -> Result<Option<Pending>> {
+    let path = Path::new(storage_dir).join(STAGING_DIR).join(PENDING_FILE);
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Ok(None);
+    };
+    let pending: Pending = serde_json::from_str(&contents)
+        .map_err(|e| UpdateError::Parse(format!("{PENDING_FILE}: {e}")))?;
+    if pending.schema != PENDING_SCHEMA {
+        return Err(UpdateError::Invalid(format!(
+            "{PENDING_FILE}: unsupported schema {}",
+            pending.schema
+        )));
+    }
+    if !is_bare_filename(&pending.version) {
+        return Err(UpdateError::Invalid(format!(
+            "{PENDING_FILE}: version {:?} cannot be a directory name",
+            pending.version
+        )));
+    }
+    Ok(Some(pending))
+}
+
+/// Removes a staged update and its marker. Used after a successful apply and
+/// when the user cancels one.
+pub fn clear_staged(storage_dir: &str) -> Result<()> {
+    let root = Path::new(storage_dir).join(STAGING_DIR);
+    if !root.exists() {
+        return Ok(());
+    }
+    refuse_reparse_point(&root)?;
+    std::fs::remove_dir_all(&root).map_err(|e| io(&root, e))
+}
+
+fn download_zip(client: &dyn HttpClient, update: &AvailableUpdate) -> Result<Vec<u8>> {
+    let expected = &update.manifest.artifacts.zip;
+    let body = client
+        .get(&update.zip_url, None)?
+        .into_body(&update.zip_url)?;
+    // The size check is not security - the hash below is - but it turns a
+    // truncated download into an error that says so.
+    if body.len() as u64 != expected.size {
+        return Err(UpdateError::Invalid(format!(
+            "{}: manifest says {} bytes, download is {}",
+            expected.name,
+            expected.size,
+            body.len()
+        )));
+    }
+    verify_sha512(&body, &expected.sha512, &expected.name)?;
+    Ok(body)
+}
+
+/// Pulls every file the manifest lists out of the archive and verifies it,
+/// returning them all only if all of them verified. Nothing is written until
+/// this has succeeded, so a bundle with one bad file leaves no files behind.
+fn extract_verified(zip_bytes: &[u8], manifest: &Manifest) -> Result<Vec<(String, Vec<u8>)>> {
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(zip_bytes))
+        .map_err(|e| UpdateError::Archive(e.to_string()))?;
+
+    // Refuse the whole archive over one unsafe name rather than skipping it. CI
+    // produces a flat zip of bare filenames; anything else means the bytes are
+    // not what the manifest describes, and the safe move is to stop.
+    for index in 0..archive.len() {
+        let entry = archive
+            .by_index_raw(index)
+            .map_err(|e| UpdateError::Archive(e.to_string()))?;
+        let name = entry.name().to_owned();
+        if !is_bare_filename(&name) {
+            return Err(UpdateError::UnsafeEntry(name));
+        }
+    }
+
+    // Driven by the manifest, not by the archive: an entry the manifest does not
+    // list is never read and never written, whatever it claims to be.
+    let mut extracted = Vec::with_capacity(manifest.files.len());
+    for file in &manifest.files {
+        let mut entry = archive
+            .by_name(&file.path)
+            .map_err(|_| UpdateError::MissingEntry(file.path.clone()))?;
+        let mut bytes = Vec::with_capacity(entry.size() as usize);
+        entry
+            .read_to_end(&mut bytes)
+            .map_err(|e| UpdateError::Archive(format!("{}: {e}", file.path)))?;
+        verify_sha512(&bytes, &file.sha512, &file.path)?;
+        extracted.push((file.path.clone(), bytes));
+    }
+    Ok(extracted)
+}
+
+/// Creates the staging root, refusing to use it if it is a link to somewhere
+/// else.
+fn prepare_dir(root: &Path) -> Result<()> {
+    if root.exists() {
+        refuse_reparse_point(root)?;
+        if !root.is_dir() {
+            return Err(UpdateError::Io(format!(
+                "{} exists and is not a directory",
+                root.display()
+            )));
+        }
+    }
+    std::fs::create_dir_all(root).map_err(|e| io(root, e))
+}
+
+/// Refuses a path that is a symlink or, on Windows, a junction.
+///
+/// `symlink_metadata` does not follow the link, so this sees the reparse point
+/// itself. Without it, `remove_dir_all` and every write below would land
+/// wherever the link points - which is the whole trick, given the helper later
+/// copies these files while elevated.
+fn refuse_reparse_point(path: &Path) -> Result<()> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|e| io(path, e))?;
+    if metadata.file_type().is_symlink() {
+        return Err(UpdateError::Io(format!(
+            "{} is a link; refusing to stage through it",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Writes one staged file, refusing to write through an existing link.
+fn write_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    if path.exists() {
+        refuse_reparse_point(path)?;
+    }
+    std::fs::write(path, bytes).map_err(|e| io(path, e))
+}
+
+fn io(path: &Path, e: std::io::Error) -> UpdateError {
+    UpdateError::Io(format!("{}: {e}", path.display()))
+}

--- a/packages/mbrc-release/src/state.rs
+++ b/packages/mbrc-release/src/state.rs
@@ -1,0 +1,241 @@
+//! Machine-written update bookkeeping: `update_state.json`.
+//!
+//! This is deliberately *not* in `core_settings.json`. That file is the user's
+//! preferences, edited by the Configure panel, and the panel round-trips only the
+//! fields it knows about. Putting a skipped version or a cached ETag in there
+//! would mean a save of an unrelated setting could silently un-skip a release -
+//! a bug whose cause nobody would ever guess from the symptom.
+//!
+//! It also draws the right line: nothing here is a preference. It is the record
+//! of what the updater has already done.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
+
+use crate::error::{Result, UpdateError};
+
+/// Filename under the core's storage directory.
+pub const STATE_FILE: &str = "update_state.json";
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UpdateState {
+    /// When the last check completed, RFC3339. Written for a 304 too: the point
+    /// is to rate-limit checks, and a 304 was a check.
+    pub last_check: Option<String>,
+    /// The `ETag` of the release document the last successful check saw.
+    pub etag: Option<String>,
+    /// A version the user chose to skip. Compared as a string, not as semver: it
+    /// records "not this one", and any newer release is a different string.
+    pub skipped_version: Option<String>,
+    /// Checks that have failed in a row. Drives the retry backoff so a network
+    /// that is down does not mean a request on every tick, and so a check that
+    /// fails does not have to wait the full interval either.
+    pub consecutive_failures: u32,
+}
+
+/// First retry delay after a failed check; each further failure doubles it.
+const FIRST_RETRY_MINUTES: i64 = 15;
+
+/// Where doubling stops (2^6 x 15 minutes = 16 hours), so the delay stays under
+/// a 24 hour interval and the backoff never outlives it.
+const MAX_RETRY_DOUBLINGS: u32 = 6;
+
+impl UpdateState {
+    /// Reads the state file. A missing, unreadable, or corrupt file yields the
+    /// default state rather than an error: the worst it costs is one extra
+    /// check and a re-prompt for a skipped version, and neither is worth failing
+    /// the caller over. Use [`load_checked`](Self::load_checked) where the caller
+    /// wants to log that it happened.
+    pub fn load(dir: &str) -> Self {
+        Self::load_checked(dir).unwrap_or_default()
+    }
+
+    /// [`load`](Self::load), but reporting a corrupt file so the core can log it.
+    /// A missing file is not a failure - it is simply the first run.
+    pub fn load_checked(dir: &str) -> Result<Self> {
+        let path = Self::path(dir);
+        let Ok(contents) = std::fs::read_to_string(&path) else {
+            return Ok(Self::default());
+        };
+        serde_json::from_str(&contents)
+            .map_err(|e| UpdateError::Parse(format!("{STATE_FILE}: {e}")))
+    }
+
+    /// Writes the state file, creating the directory if needed.
+    ///
+    /// Via a temporary file and a rename, so a crash mid-write cannot leave a
+    /// half-written file that the next load discards along with the skipped
+    /// version it held.
+    pub fn save(&self, dir: &str) -> Result<()> {
+        std::fs::create_dir_all(dir).map_err(|e| UpdateError::Io(format!("{dir}: {e}")))?;
+        let path = Self::path(dir);
+        let temp = path.with_extension("json.tmp");
+        let json = serde_json::to_string_pretty(self)
+            .map_err(|e| UpdateError::Io(format!("serialize update state: {e}")))?;
+        std::fs::write(&temp, json)
+            .map_err(|e| UpdateError::Io(format!("{}: {e}", temp.display())))?;
+        std::fs::rename(&temp, &path).map_err(|e| UpdateError::Io(format!("{STATE_FILE}: {e}")))
+    }
+
+    fn path(dir: &str) -> PathBuf {
+        Path::new(dir).join(STATE_FILE)
+    }
+
+    /// Whether the interval since [`last_check`](Self::last_check) has elapsed.
+    ///
+    /// An absent or unparseable timestamp is due: never having checked and having
+    /// lost the record of checking are the same situation from here.
+    pub fn is_due(&self, now: OffsetDateTime, interval_hours: u64) -> bool {
+        let Some(last) = self
+            .last_check
+            .as_deref()
+            .and_then(|raw| OffsetDateTime::parse(raw, &Rfc3339).ok())
+        else {
+            return true;
+        };
+        // A last_check in the future (a clock that was wound back, or a roamed
+        // profile) would otherwise suppress checks until real time caught up.
+        if last > now {
+            return true;
+        }
+        now - last >= self.wait(interval_hours)
+    }
+
+    /// How long to wait after the last check before the next one.
+    ///
+    /// Normally the configured interval. After a failure it is the backoff
+    /// instead, which is always the shorter of the two: a failed check should be
+    /// retried sooner than a successful one, never later.
+    fn wait(&self, interval_hours: u64) -> Duration {
+        let interval = Duration::hours(interval_hours as i64);
+        if self.consecutive_failures == 0 {
+            return interval;
+        }
+        let doublings = (self.consecutive_failures - 1).min(MAX_RETRY_DOUBLINGS);
+        let backoff = Duration::minutes(FIRST_RETRY_MINUTES * (1i64 << doublings));
+        backoff.min(interval)
+    }
+
+    /// Whether the user asked to skip exactly this version.
+    pub fn is_skipped(&self, version: &str) -> bool {
+        self.skipped_version.as_deref() == Some(version)
+    }
+
+    /// Records that a check happened at `now`, keeping the server's `ETag` when
+    /// it sent one and the previous one otherwise (a 304 carries no `ETag`).
+    pub fn record_check(&mut self, now: OffsetDateTime, etag: Option<String>) {
+        self.last_check = now.format(&Rfc3339).ok();
+        if etag.is_some() {
+            self.etag = etag;
+        }
+    }
+
+    /// Records a failed check, so the next one waits out the backoff.
+    pub fn record_failure(&mut self, now: OffsetDateTime) {
+        self.last_check = now.format(&Rfc3339).ok();
+        self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+    }
+
+    /// Clears the failure streak after a check that worked.
+    pub fn clear_failures(&mut self) {
+        self.consecutive_failures = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> String {
+        let dir = std::env::temp_dir().join(name);
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir.to_string_lossy().into_owned()
+    }
+
+    fn at(raw: &str) -> OffsetDateTime {
+        OffsetDateTime::parse(raw, &Rfc3339).unwrap()
+    }
+
+    #[test]
+    fn round_trips_through_the_file() {
+        let dir = temp_dir("mbrc-update-state-roundtrip");
+        let mut state = UpdateState::default();
+        state.record_check(at("2026-08-04T10:00:00Z"), Some("\"abc\"".into()));
+        state.skipped_version = Some("1.6.0".into());
+        state.save(&dir).unwrap();
+
+        let loaded = UpdateState::load(&dir);
+        assert_eq!(loaded, state);
+        assert!(loaded.is_skipped("1.6.0"));
+        assert!(!loaded.is_skipped("1.6.1"));
+    }
+
+    #[test]
+    fn a_missing_or_corrupt_file_is_the_default_state() {
+        let missing = "/no/such/dir/at/all";
+        assert_eq!(UpdateState::load(missing), UpdateState::default());
+        // A first run is not an error; a corrupt file is one worth logging.
+        assert!(UpdateState::load_checked(missing).is_ok());
+
+        let dir = temp_dir("mbrc-update-state-corrupt");
+        std::fs::write(Path::new(&dir).join(STATE_FILE), "{ not json").unwrap();
+        assert_eq!(UpdateState::load(&dir), UpdateState::default());
+        assert!(UpdateState::load_checked(&dir).is_err());
+    }
+
+    #[test]
+    fn the_interval_gates_checks() {
+        let mut state = UpdateState::default();
+        assert!(state.is_due(at("2026-08-04T10:00:00Z"), 24)); // never checked
+
+        state.record_check(at("2026-08-04T10:00:00Z"), None);
+        assert!(!state.is_due(at("2026-08-04T20:00:00Z"), 24));
+        assert!(state.is_due(at("2026-08-05T10:00:00Z"), 24)); // exactly 24h
+        assert!(state.is_due(at("2026-08-04T11:00:00Z"), 0)); // interval 0 = always
+    }
+
+    #[test]
+    fn a_failed_check_is_retried_sooner_than_the_interval() {
+        let mut state = UpdateState::default();
+        state.record_failure(at("2026-08-04T10:00:00Z"));
+        assert_eq!(state.consecutive_failures, 1);
+
+        // 15 minutes after the first failure, not 24 hours.
+        assert!(!state.is_due(at("2026-08-04T10:10:00Z"), 24));
+        assert!(state.is_due(at("2026-08-04T10:15:00Z"), 24));
+
+        state.record_failure(at("2026-08-04T10:15:00Z"));
+        assert!(!state.is_due(at("2026-08-04T10:35:00Z"), 24)); // doubled to 30m
+        assert!(state.is_due(at("2026-08-04T10:45:00Z"), 24));
+
+        // The backoff never exceeds the configured interval: an hourly check
+        // stays hourly however long the failure streak gets.
+        for _ in 0..20 {
+            state.record_failure(at("2026-08-04T10:45:00Z"));
+        }
+        assert!(state.is_due(at("2026-08-04T11:45:00Z"), 1));
+
+        state.clear_failures();
+        assert!(!state.is_due(at("2026-08-04T11:00:00Z"), 24));
+    }
+
+    #[test]
+    fn a_last_check_in_the_future_does_not_suppress_checks() {
+        let mut state = UpdateState::default();
+        state.record_check(at("2027-01-01T00:00:00Z"), None);
+        assert!(state.is_due(at("2026-08-04T10:00:00Z"), 24));
+    }
+
+    #[test]
+    fn a_304_keeps_the_previous_etag() {
+        let mut state = UpdateState::default();
+        state.record_check(at("2026-08-04T10:00:00Z"), Some("\"v1\"".into()));
+        state.record_check(at("2026-08-05T10:00:00Z"), None);
+        assert_eq!(state.etag.as_deref(), Some("\"v1\""));
+        assert_eq!(state.last_check.as_deref(), Some("2026-08-05T10:00:00Z"));
+    }
+}

--- a/packages/mbrc-release/src/verify.rs
+++ b/packages/mbrc-release/src/verify.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 /// A release public key compiled in from `keys/*.pub`.
+#[derive(Debug)]
 pub struct TrustedKey {
     /// The key's filename stem, for logging which key verified a release.
     pub name: &'static str,
@@ -30,7 +31,19 @@ include!(concat!(env!("OUT_DIR"), "/trusted_keys.rs"));
 /// reaches the schema logic. Returns the manifest and the name of the key that
 /// verified it.
 pub fn verify_manifest(manifest_bytes: &[u8], signature: &str) -> Result<(Manifest, &'static str)> {
-    let key_name = verify_signature(manifest_bytes, signature)?;
+    verify_manifest_with(manifest_bytes, signature, TRUSTED_KEYS)
+}
+
+/// [`verify_manifest`] against an explicit trust list, for the same reason
+/// [`verify_signature_with`] exists: the tests above the network seam drive the
+/// whole check against the committed test keypair, and the release keys stay
+/// unreachable from a test build.
+pub fn verify_manifest_with(
+    manifest_bytes: &[u8],
+    signature: &str,
+    keys: &'static [TrustedKey],
+) -> Result<(Manifest, &'static str)> {
+    let key_name = verify_signature_with(manifest_bytes, signature, keys)?;
     let manifest = Manifest::parse(manifest_bytes)?;
     Ok((manifest, key_name))
 }

--- a/packages/mbrc-release/src/version.rs
+++ b/packages/mbrc-release/src/version.rs
@@ -1,0 +1,128 @@
+//! Turning the product's version strings into comparable semver.
+//!
+//! The version reaches the core as a .NET `System.Version.ToString()`, which is
+//! four components (`"1.5.0.0"`), while the manifest carries three (`"1.5.0"`).
+//! `semver` parses neither interchangeably: it rejects the four-component form
+//! outright. Everything therefore goes through [`parse`] before it is compared.
+//!
+//! Only major.minor.patch has ever been meaningful in this project - the fourth
+//! component is an artefact of the .NET type and is always zero in a release - so
+//! normalizing is dropping it, not losing information.
+
+use semver::Version;
+
+use crate::error::{Result, UpdateError};
+
+/// Parses a product version into comparable semver.
+///
+/// Accepts what the various producers actually emit:
+///
+/// - four components from .NET (`"1.5.0.0"`); the revision is dropped
+/// - fewer than three (`"1.5"`); the missing components are zero
+/// - an optional `v` prefix, as the git tags carry
+/// - a prerelease or build suffix (`"1.6.0-nightly.20260804"`), kept intact, so
+///   nightly ordering stays semver's problem rather than ours
+///
+/// A component that is not a number, or a fifth component, is an error: those
+/// mean the caller handed over something that is not a version at all, and
+/// guessing would put the updater on the wrong side of a comparison.
+pub fn parse(raw: &str) -> Result<Version> {
+    let trimmed = raw.trim();
+    let trimmed = trimmed.strip_prefix(['v', 'V']).unwrap_or(trimmed);
+    if trimmed.is_empty() {
+        return Err(UpdateError::Version("version is empty".into()));
+    }
+
+    // Split the numeric core off any prerelease/build suffix before counting
+    // components, so the `.` inside `-nightly.20260804` is not mistaken for one.
+    let split = trimmed.find(['-', '+']).unwrap_or(trimmed.len());
+    let (core, suffix) = trimmed.split_at(split);
+
+    let mut parts = core.split('.');
+    let mut numbers = [0u64; 3];
+    for (index, slot) in numbers.iter_mut().enumerate() {
+        let Some(part) = parts.next() else { break };
+        *slot = part.parse().map_err(|_| {
+            UpdateError::Version(format!(
+                "{raw:?}: component {} is not a number ({part:?})",
+                index + 1
+            ))
+        })?;
+    }
+
+    // A fourth component is the .NET revision and is dropped, but it still has to
+    // look like one: a trailing `.beta` would otherwise vanish silently.
+    if let Some(revision) = parts.next() {
+        revision.parse::<u64>().map_err(|_| {
+            UpdateError::Version(format!("{raw:?}: revision is not a number ({revision:?})"))
+        })?;
+    }
+    if parts.next().is_some() {
+        return Err(UpdateError::Version(format!(
+            "{raw:?}: more than four components"
+        )));
+    }
+
+    let [major, minor, patch] = numbers;
+    Version::parse(&format!("{major}.{minor}.{patch}{suffix}"))
+        .map_err(|e| UpdateError::Version(format!("{raw:?}: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Version {
+        parse(s).unwrap_or_else(|e| panic!("{s:?} should parse: {e}"))
+    }
+
+    #[test]
+    fn drops_the_dotnet_revision() {
+        // What QueryType::PluginVersion actually returns.
+        assert_eq!(v("1.5.0.0"), Version::new(1, 5, 0));
+        assert_eq!(v("1.5.0.7"), Version::new(1, 5, 0));
+    }
+
+    #[test]
+    fn accepts_the_manifest_and_tag_forms() {
+        assert_eq!(v("1.5.0"), Version::new(1, 5, 0));
+        assert_eq!(v("v1.5.0"), Version::new(1, 5, 0));
+        assert_eq!(v(" 1.5.0 "), Version::new(1, 5, 0));
+    }
+
+    #[test]
+    fn pads_missing_components() {
+        assert_eq!(v("1.5"), Version::new(1, 5, 0));
+        assert_eq!(v("2"), Version::new(2, 0, 0));
+    }
+
+    #[test]
+    fn keeps_prerelease_and_build_suffixes() {
+        assert_eq!(
+            v("1.6.0-nightly.20260804").to_string(),
+            "1.6.0-nightly.20260804"
+        );
+        // The two forms of the same nightly must compare equal, which is the
+        // whole point of normalizing before comparing.
+        assert_eq!(v("1.6.0.0-nightly.1"), v("1.6.0-nightly.1"));
+        assert_eq!(v("1.6.0+build.5").to_string(), "1.6.0+build.5");
+    }
+
+    #[test]
+    fn a_prerelease_orders_below_its_release() {
+        // Semver's rule, and the reason nightly ordering is left to it: a
+        // nightly is older than the stable release of the same number.
+        assert!(v("1.6.0-nightly.20260804") < v("1.6.0"));
+        assert!(v("1.5.0") < v("1.6.0-nightly.20260804"));
+    }
+
+    #[test]
+    fn rejects_what_is_not_a_version() {
+        assert!(parse("").is_err());
+        assert!(parse("   ").is_err());
+        assert!(parse("abc").is_err());
+        assert!(parse("1.x.0").is_err());
+        assert!(parse("1.5.0.beta").is_err());
+        assert!(parse("1.2.3.4.5").is_err());
+    }
+}

--- a/packages/mbrc-release/tests/check_tests.rs
+++ b/packages/mbrc-release/tests/check_tests.rs
@@ -1,0 +1,329 @@
+//! The update check, driven end to end against a stub HTTP client.
+//!
+//! These run on any host: the only Windows-bound part of the updater is the one
+//! implementation of `HttpClient`, which is exactly why the trait is there.
+//!
+//! The manifest is the same golden fixture the verification tests use, signed
+//! with the committed test key. Its version (1.5.0) is fixed, so the cases below
+//! vary the *running* version instead - which is the input that actually varies
+//! in the field.
+
+mod support;
+
+use mbrc_release::{check, Channel, CheckOptions, CheckOutcome, UpdateError, UpdateState};
+use support::{OfflineHttp, StubHttp, TEST_KEYS};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const MANIFEST: &str = include_str!("fixtures/manifest.json");
+const SIGNATURE: &str = include_str!("fixtures/manifest.json.minisig");
+const RELEASE_VERSION: &str = "1.5.0";
+const API: &str = "https://api.github.com/repos/test/repo";
+const NOW: &str = "2026-08-04T10:00:00Z";
+
+fn at(raw: &str) -> OffsetDateTime {
+    OffsetDateTime::parse(raw, &Rfc3339).unwrap()
+}
+
+/// A stub serving the golden release on the stable channel.
+fn stable_release() -> StubHttp {
+    let stub = StubHttp::default();
+    stub.serve_release(API, "releases/latest", RELEASE_VERSION);
+    stub.serve("https://assets.test/manifest.json", MANIFEST.as_bytes());
+    stub.serve(
+        "https://assets.test/manifest.json.minisig",
+        SIGNATURE.as_bytes(),
+    );
+    stub.serve(
+        "https://assets.test/musicbee_remote_1.5.0.zip",
+        b"zip bytes",
+    );
+    stub
+}
+
+fn options(current: &str) -> CheckOptions<'_> {
+    CheckOptions {
+        repo: "test/repo",
+        keys: TEST_KEYS,
+        ..CheckOptions::new(current, Channel::Stable)
+    }
+}
+
+fn forced(current: &str) -> CheckOptions<'_> {
+    CheckOptions {
+        force: true,
+        ..options(current)
+    }
+}
+
+#[test]
+fn a_newer_release_is_offered() {
+    let stub = stable_release();
+    let mut state = UpdateState::default();
+
+    // The running plugin reports four components; the manifest carries three.
+    let outcome = check(&stub, &options("1.4.0.0"), &mut state, at(NOW)).unwrap();
+
+    let CheckOutcome::Available(update) = outcome else {
+        panic!("expected an update, got {outcome:?}");
+    };
+    assert_eq!(update.manifest.version, RELEASE_VERSION);
+    assert_eq!(update.key_name, "test");
+    assert_eq!(
+        update.zip_url,
+        "https://assets.test/musicbee_remote_1.5.0.zip"
+    );
+    // The signed bytes are kept verbatim: a re-serialized manifest is a
+    // different document as far as the signature is concerned.
+    assert_eq!(update.manifest_bytes, MANIFEST.as_bytes());
+    assert_eq!(update.signature, SIGNATURE);
+    // Checking does not download the payload.
+    assert!(!stub.requested("https://assets.test/musicbee_remote_1.5.0.zip"));
+    assert_eq!(state.last_check.as_deref(), Some(NOW));
+    assert_eq!(state.consecutive_failures, 0);
+}
+
+#[test]
+fn the_same_or_an_older_release_is_not() {
+    for current in ["1.5.0.0", "1.5.0", "1.6.0.0"] {
+        let stub = stable_release();
+        let mut state = UpdateState::default();
+        let outcome = check(&stub, &options(current), &mut state, at(NOW)).unwrap();
+        assert!(
+            matches!(&outcome, CheckOutcome::UpToDate { latest } if latest == RELEASE_VERSION),
+            "{current} against {RELEASE_VERSION} should be up to date, got {outcome:?}"
+        );
+    }
+}
+
+#[test]
+fn a_nightly_is_never_offered_an_older_stable() {
+    let stub = stable_release();
+    let mut state = UpdateState::default();
+
+    // Running a nightly of 1.6.0 while stable is 1.5.0: a downgrade, refused.
+    let outcome = check(
+        &stub,
+        &options("1.6.0-nightly.20260804"),
+        &mut state,
+        at(NOW),
+    )
+    .unwrap();
+    assert!(
+        matches!(outcome, CheckOutcome::UpToDate { .. }),
+        "{outcome:?}"
+    );
+
+    // Running a nightly of 1.5.0 while stable is 1.5.0: the finished release is
+    // newer than the prerelease of it, so that one is offered.
+    let stub = stable_release();
+    let mut state = UpdateState::default();
+    let outcome = check(
+        &stub,
+        &options("1.5.0-nightly.20260701"),
+        &mut state,
+        at(NOW),
+    )
+    .unwrap();
+    assert!(matches!(outcome, CheckOutcome::Available(_)), "{outcome:?}");
+}
+
+#[test]
+fn each_channel_asks_the_right_endpoint() {
+    assert_eq!(
+        options("1.5.0").endpoint(),
+        "https://api.github.com/repos/test/repo/releases/latest"
+    );
+    assert_eq!(
+        CheckOptions {
+            repo: "test/repo",
+            ..CheckOptions::new("1.5.0", Channel::Nightly)
+        }
+        .endpoint(),
+        "https://api.github.com/repos/test/repo/releases/tags/nightly"
+    );
+}
+
+#[test]
+fn a_manifest_from_the_wrong_channel_is_refused() {
+    // The nightly tag serving the stable manifest: the tag and its assets
+    // disagree, so nothing is offered even though the version would qualify.
+    let stub = StubHttp::default();
+    stub.serve_release(API, "releases/tags/nightly", RELEASE_VERSION);
+    stub.serve("https://assets.test/manifest.json", MANIFEST.as_bytes());
+    stub.serve(
+        "https://assets.test/manifest.json.minisig",
+        SIGNATURE.as_bytes(),
+    );
+
+    let mut state = UpdateState::default();
+    let error = check(
+        &stub,
+        &CheckOptions {
+            repo: "test/repo",
+            keys: TEST_KEYS,
+            ..CheckOptions::new("1.4.0.0", Channel::Nightly)
+        },
+        &mut state,
+        at(NOW),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(&error, UpdateError::Invalid(m) if m.contains("channel")),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_tampered_manifest_never_reaches_the_version_comparison() {
+    let stub = stable_release();
+    stub.serve(
+        "https://assets.test/manifest.json",
+        MANIFEST.replace("1.5.0", "9.9.9").as_bytes(),
+    );
+
+    let mut state = UpdateState::default();
+    let error = check(&stub, &options("1.4.0.0"), &mut state, at(NOW)).unwrap_err();
+    assert!(
+        matches!(error, UpdateError::UntrustedSignature),
+        "{error:?}"
+    );
+    assert!(!stub.requested("https://assets.test/musicbee_remote_9.9.9.zip"));
+    // A failed check still counts, so the next one backs off.
+    assert_eq!(state.consecutive_failures, 1);
+}
+
+#[test]
+fn a_release_missing_its_manifest_is_an_error_not_an_update() {
+    let stub = StubHttp::default();
+    stub.serve(
+        &format!("{API}/releases/latest"),
+        br#"{"tag_name":"v1.5.0","assets":[]}"#,
+    );
+    let mut state = UpdateState::default();
+    let error = check(&stub, &options("1.4.0.0"), &mut state, at(NOW)).unwrap_err();
+    assert!(
+        matches!(&error, UpdateError::Invalid(m) if m.contains("manifest.json")),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_304_costs_one_request_and_no_verification() {
+    let stub = stable_release();
+    let mut state = UpdateState::default();
+    check(&stub, &options("1.4.0.0"), &mut state, at(NOW)).unwrap();
+    let after_first = stub.request_count();
+    assert_eq!(state.etag.as_deref(), Some(StubHttp::ETAG));
+
+    stub.reply_not_modified();
+    let outcome = check(
+        &stub,
+        &options("1.4.0.0"),
+        &mut state,
+        at("2026-08-06T10:00:00Z"),
+    )
+    .unwrap();
+
+    assert!(matches!(outcome, CheckOutcome::NotModified), "{outcome:?}");
+    // The release document, and nothing else: no manifest, no signature.
+    assert_eq!(stub.request_count(), after_first + 1);
+    assert_eq!(state.etag.as_deref(), Some(StubHttp::ETAG));
+    assert_eq!(state.last_check.as_deref(), Some("2026-08-06T10:00:00Z"));
+}
+
+#[test]
+fn the_interval_suppresses_a_second_check_but_check_now_goes_through() {
+    let stub = stable_release();
+    let mut state = UpdateState::default();
+    check(&stub, &options("1.4.0.0"), &mut state, at(NOW)).unwrap();
+    let after_first = stub.request_count();
+
+    let outcome = check(
+        &stub,
+        &options("1.4.0.0"),
+        &mut state,
+        at("2026-08-04T20:00:00Z"),
+    )
+    .unwrap();
+    assert!(matches!(outcome, CheckOutcome::NotDue), "{outcome:?}");
+    assert_eq!(stub.request_count(), after_first, "nothing was requested");
+
+    let outcome = check(
+        &stub,
+        &forced("1.4.0.0"),
+        &mut state,
+        at("2026-08-04T20:00:00Z"),
+    )
+    .unwrap();
+    assert!(matches!(outcome, CheckOutcome::Available(_)), "{outcome:?}");
+}
+
+#[test]
+fn a_skipped_version_is_not_offered() {
+    let stub = stable_release();
+    let mut state = UpdateState {
+        skipped_version: Some(RELEASE_VERSION.into()),
+        ..UpdateState::default()
+    };
+
+    let outcome = check(&stub, &options("1.4.0.0"), &mut state, at(NOW)).unwrap();
+    assert!(
+        matches!(&outcome, CheckOutcome::Skipped { version } if version == RELEASE_VERSION),
+        "{outcome:?}"
+    );
+
+    // Skipping says "not this one", so a different version is unaffected.
+    let mut state = UpdateState {
+        skipped_version: Some("1.4.9".into()),
+        ..UpdateState::default()
+    };
+    let outcome = check(&stub, &forced("1.4.0.0"), &mut state, at(NOW)).unwrap();
+    assert!(matches!(outcome, CheckOutcome::Available(_)), "{outcome:?}");
+}
+
+#[test]
+fn a_failing_check_backs_off_instead_of_retrying_on_every_tick() {
+    let mut state = UpdateState::default();
+    assert!(check(&OfflineHttp, &options("1.4.0.0"), &mut state, at(NOW)).is_err());
+    assert_eq!(state.consecutive_failures, 1);
+
+    // Sooner than the 24 hour interval, but not immediately.
+    let outcome = check(
+        &OfflineHttp,
+        &options("1.4.0.0"),
+        &mut state,
+        at("2026-08-04T10:05:00Z"),
+    )
+    .unwrap();
+    assert!(matches!(outcome, CheckOutcome::NotDue), "{outcome:?}");
+
+    assert!(check(
+        &OfflineHttp,
+        &options("1.4.0.0"),
+        &mut state,
+        at("2026-08-04T10:20:00Z")
+    )
+    .is_err());
+    assert_eq!(state.consecutive_failures, 2);
+
+    // A check that works clears the streak.
+    let stub = stable_release();
+    check(
+        &stub,
+        &forced("1.4.0.0"),
+        &mut state,
+        at("2026-08-04T11:00:00Z"),
+    )
+    .unwrap();
+    assert_eq!(state.consecutive_failures, 0);
+}
+
+#[test]
+fn an_unreadable_running_version_is_an_error() {
+    let stub = stable_release();
+    let mut state = UpdateState::default();
+    let error = check(&stub, &options(""), &mut state, at(NOW)).unwrap_err();
+    assert!(matches!(error, UpdateError::Version(_)), "{error:?}");
+    // Nothing was fetched: the check gave up before it went near the network.
+    assert_eq!(stub.request_count(), 0);
+}

--- a/packages/mbrc-release/tests/manifest_tests.rs
+++ b/packages/mbrc-release/tests/manifest_tests.rs
@@ -114,6 +114,28 @@ fn rejects_paths_that_are_not_bare_filenames() {
     }
 }
 
+/// Names that stay inside the directory but still do not mean what they look
+/// like on Windows, where these files are written.
+#[test]
+fn rejects_windows_traps_that_are_not_path_traversal() {
+    for evil in [
+        "nul",              // a device, in every directory
+        "NUL.dll",          // still a device: the extension is ignored
+        "com1.dll",         //
+        "mb_remote.dll.",   // the trailing dot is stripped, so this is the same file
+        "mb_remote.dll ",   // as is the trailing space
+        "mb_remote:stream", // an alternate data stream on the real file
+        "mb_remote*.dll",   // a wildcard, refused by the filesystem anyway
+        "mb\u{0}remote.dll",
+    ] {
+        let json = GOLDEN.replace("\"mb_remote.dll\"", &format!("{evil:?}"));
+        assert!(
+            Manifest::parse(json.as_bytes()).is_err(),
+            "{evil:?} should be rejected as a file path"
+        );
+    }
+}
+
 #[test]
 fn rejects_artifact_names_that_are_not_bare_filenames() {
     let json = GOLDEN.replace(

--- a/packages/mbrc-release/tests/stage_tests.rs
+++ b/packages/mbrc-release/tests/stage_tests.rs
@@ -1,0 +1,325 @@
+//! Staging: what gets written, where, and what refuses to be written at all.
+//!
+//! These manifests are built in the test rather than signed, because staging's
+//! contract starts *after* verification: `check` proves the manifest came from a
+//! release key, and `stage` is what happens next. The signature bytes here are
+//! opaque - staging copies them to disk for the helper to re-verify, and never
+//! looks at them.
+
+mod support;
+
+use std::io::Write;
+use std::path::Path;
+
+use mbrc_release::{
+    clear_staged,
+    manifest::{Artifact, Artifacts, FileEntry},
+    read_pending, stage,
+    stage::{PENDING_FILE, PENDING_SCHEMA, STAGING_DIR},
+    AvailableUpdate, Channel, Manifest, UpdateError,
+};
+use sha2::{Digest, Sha512};
+use support::StubHttp;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const ZIP_URL: &str = "https://assets.test/musicbee_remote_1.6.0.zip";
+const NOW: &str = "2026-08-04T10:00:00Z";
+
+fn now() -> OffsetDateTime {
+    OffsetDateTime::parse(NOW, &Rfc3339).unwrap()
+}
+
+fn sha512(bytes: &[u8]) -> String {
+    hex::encode(Sha512::digest(bytes))
+}
+
+fn temp_dir(name: &str) -> String {
+    let dir = std::env::temp_dir().join(format!("mbrc-stage-{name}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.to_string_lossy().into_owned()
+}
+
+/// A zip with stored (uncompressed) entries - the reader path is what is under
+/// test, not the compressor.
+fn build_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let mut writer = zip::ZipWriter::new(std::io::Cursor::new(Vec::new()));
+    let options: zip::write::FileOptions<'_, ()> =
+        zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (name, bytes) in entries {
+        writer.start_file(*name, options).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+fn manifest_for(files: &[(&str, &[u8])], zip_bytes: &[u8]) -> Manifest {
+    Manifest {
+        schema: 1,
+        channel: Channel::Stable,
+        version: "1.6.0".into(),
+        released_at: NOW.into(),
+        abi_version: 3,
+        min_musicbee_build: 6500,
+        notes_url: "https://example.test/notes".into(),
+        artifacts: Artifacts {
+            zip: Artifact {
+                name: "musicbee_remote_1.6.0.zip".into(),
+                size: zip_bytes.len() as u64,
+                sha512: sha512(zip_bytes),
+            },
+            installer: Artifact {
+                name: "musicbee_remote_1.6.0.exe".into(),
+                size: 1,
+                sha512: sha512(b"installer"),
+            },
+        },
+        files: files
+            .iter()
+            .map(|(path, bytes)| FileEntry {
+                path: (*path).into(),
+                sha512: sha512(bytes),
+            })
+            .collect(),
+    }
+}
+
+fn available(manifest: Manifest) -> AvailableUpdate {
+    AvailableUpdate {
+        manifest_bytes: manifest.to_json().unwrap().into_bytes(),
+        manifest,
+        signature: "untrusted comment: test\nRWTest\n".into(),
+        zip_url: ZIP_URL.into(),
+        key_name: "test",
+    }
+}
+
+/// The happy path: an archive whose listed files all verify.
+fn good_bundle() -> (StubHttp, AvailableUpdate) {
+    let payload: &[(&str, &[u8])] = &[
+        ("mb_remote.dll", b"managed shim bytes"),
+        ("mbrc_core.dll", b"native core bytes"),
+        ("mbrc-helper.exe", b"helper bytes"),
+    ];
+    // LICENSE rides along in the real zip and is not listed in the manifest.
+    let mut entries = payload.to_vec();
+    entries.push(("LICENSE", b"license text"));
+    let zip = build_zip(&entries);
+
+    let stub = StubHttp::default();
+    stub.serve(ZIP_URL, &zip);
+    (stub, available(manifest_for(payload, &zip)))
+}
+
+#[test]
+fn stages_every_listed_file_and_the_marker_last() {
+    let dir = temp_dir("happy");
+    let (stub, update) = good_bundle();
+
+    let staged = stage(&stub, &update, &dir, now()).unwrap();
+
+    assert_eq!(staged.version, "1.6.0");
+    assert_eq!(staged.dir, Path::new(&dir).join(STAGING_DIR).join("1.6.0"));
+    assert_eq!(
+        staged.files,
+        vec!["mb_remote.dll", "mbrc_core.dll", "mbrc-helper.exe"]
+    );
+
+    assert_eq!(
+        std::fs::read(staged.dir.join("mb_remote.dll")).unwrap(),
+        b"managed shim bytes"
+    );
+    // The signed manifest and its signature are staged alongside, so the
+    // elevated apply re-verifies from these rather than trusting the marker.
+    assert_eq!(
+        std::fs::read(staged.dir.join("manifest.json")).unwrap(),
+        update.manifest_bytes
+    );
+    assert_eq!(
+        std::fs::read_to_string(staged.dir.join("manifest.json.minisig")).unwrap(),
+        update.signature
+    );
+    // An unlisted entry is simply never extracted.
+    assert!(!staged.dir.join("LICENSE").exists());
+
+    let pending = read_pending(&dir).unwrap().expect("a marker");
+    assert_eq!(pending.schema, PENDING_SCHEMA);
+    assert_eq!(pending.version, "1.6.0");
+    assert_eq!(pending.staged_at, NOW);
+    // The marker names a version, never a path: the helper joins it to a
+    // storage directory it derives itself.
+    let raw =
+        std::fs::read_to_string(Path::new(&dir).join(STAGING_DIR).join(PENDING_FILE)).unwrap();
+    assert!(!raw.contains(&dir.replace('\\', "\\\\")), "{raw}");
+}
+
+#[test]
+fn an_entry_that_is_not_a_bare_filename_refuses_the_whole_bundle() {
+    for evil in [
+        "../evil.dll",
+        "sub/dir.dll",
+        "C:\\windows\\system32\\evil.dll",
+    ] {
+        let dir = temp_dir("unsafe-entry");
+        let payload: &[(&str, &[u8])] = &[("mb_remote.dll", b"managed shim bytes")];
+        let mut entries = payload.to_vec();
+        entries.push((evil, b"evil"));
+        let zip = build_zip(&entries);
+
+        let stub = StubHttp::default();
+        stub.serve(ZIP_URL, &zip);
+        let update = available(manifest_for(payload, &zip));
+
+        let error = stage(&stub, &update, &dir, now()).unwrap_err();
+        assert!(
+            matches!(error, UpdateError::UnsafeEntry(_)),
+            "{evil}: {error:?}"
+        );
+        // Refused before anything was written, marker included.
+        assert!(!Path::new(&dir).join(STAGING_DIR).join("1.6.0").exists());
+        assert!(read_pending(&dir).unwrap().is_none());
+    }
+}
+
+#[test]
+fn a_file_whose_hash_is_wrong_stages_nothing() {
+    let dir = temp_dir("hash-mismatch");
+    let payload: &[(&str, &[u8])] = &[
+        ("mb_remote.dll", b"managed shim bytes"),
+        ("mbrc_core.dll", b"native core bytes"),
+    ];
+    let zip = build_zip(&[
+        ("mb_remote.dll", b"managed shim bytes"),
+        ("mbrc_core.dll", b"native core bytes, swapped"),
+    ]);
+    let stub = StubHttp::default();
+    stub.serve(ZIP_URL, &zip);
+    let update = available(manifest_for(payload, &zip));
+
+    let error = stage(&stub, &update, &dir, now()).unwrap_err();
+    assert!(
+        matches!(error, UpdateError::HashMismatch { .. }),
+        "{error:?}"
+    );
+    // Not even the file that did verify: the bundle is applied whole or not at
+    // all, so a partial directory would only be something to clean up later.
+    assert!(!Path::new(&dir).join(STAGING_DIR).join("1.6.0").exists());
+    assert!(read_pending(&dir).unwrap().is_none());
+}
+
+#[test]
+fn a_manifest_listing_a_file_the_zip_lacks_stages_nothing() {
+    let dir = temp_dir("missing-entry");
+    let payload: &[(&str, &[u8])] = &[("mb_remote.dll", b"managed shim bytes")];
+    let zip = build_zip(&[("something_else.dll", b"whatever")]);
+    let stub = StubHttp::default();
+    stub.serve(ZIP_URL, &zip);
+    let update = available(manifest_for(payload, &zip));
+
+    let error = stage(&stub, &update, &dir, now()).unwrap_err();
+    assert!(matches!(error, UpdateError::MissingEntry(_)), "{error:?}");
+    assert!(read_pending(&dir).unwrap().is_none());
+}
+
+#[test]
+fn a_truncated_download_is_refused_before_it_is_opened() {
+    let dir = temp_dir("truncated");
+    let (_, update) = good_bundle();
+    let stub = StubHttp::default();
+    stub.serve(ZIP_URL, b"short");
+
+    let error = stage(&stub, &update, &dir, now()).unwrap_err();
+    assert!(
+        matches!(&error, UpdateError::Invalid(m) if m.contains("bytes")),
+        "{error:?}"
+    );
+}
+
+#[test]
+fn a_zip_that_is_not_a_zip_is_an_archive_error() {
+    let dir = temp_dir("not-a-zip");
+    let bytes = b"this is not a zip file".to_vec();
+    let mut manifest = manifest_for(&[("mb_remote.dll", b"x")], &bytes);
+    manifest.artifacts.zip.size = bytes.len() as u64;
+    manifest.artifacts.zip.sha512 = sha512(&bytes);
+    let stub = StubHttp::default();
+    stub.serve(ZIP_URL, &bytes);
+
+    let error = stage(&stub, &available(manifest), &dir, now()).unwrap_err();
+    assert!(matches!(error, UpdateError::Archive(_)), "{error:?}");
+}
+
+#[test]
+fn restaging_replaces_a_previous_attempt() {
+    let dir = temp_dir("restage");
+    let (stub, update) = good_bundle();
+    let staged = stage(&stub, &update, &dir, now()).unwrap();
+
+    // Something left over from an earlier attempt at the same version.
+    std::fs::write(staged.dir.join("stale.dll"), b"stale").unwrap();
+    let staged = stage(&stub, &update, &dir, now()).unwrap();
+    assert!(!staged.dir.join("stale.dll").exists());
+    assert!(staged.dir.join("mb_remote.dll").exists());
+}
+
+#[test]
+fn clearing_removes_the_staging_tree() {
+    let dir = temp_dir("clear");
+    let (stub, update) = good_bundle();
+    stage(&stub, &update, &dir, now()).unwrap();
+
+    clear_staged(&dir).unwrap();
+    assert!(read_pending(&dir).unwrap().is_none());
+    assert!(!Path::new(&dir).join(STAGING_DIR).exists());
+    // Clearing what is not there is not an error.
+    clear_staged(&dir).unwrap();
+}
+
+#[test]
+fn a_marker_that_names_a_path_or_an_unknown_schema_is_refused() {
+    let dir = temp_dir("bad-marker");
+    let root = Path::new(&dir).join(STAGING_DIR);
+    std::fs::create_dir_all(&root).unwrap();
+
+    // A version that would escape the staging root if it were joined blindly.
+    // The helper re-checks this too (#151); this is the first of the two.
+    std::fs::write(
+        root.join(PENDING_FILE),
+        r#"{"schema":1,"version":"../../plugins","staged_at":"","files":[]}"#,
+    )
+    .unwrap();
+    assert!(matches!(
+        read_pending(&dir).unwrap_err(),
+        UpdateError::Invalid(_)
+    ));
+
+    std::fs::write(
+        root.join(PENDING_FILE),
+        r#"{"schema":99,"version":"1.6.0","staged_at":"","files":[]}"#,
+    )
+    .unwrap();
+    assert!(matches!(
+        read_pending(&dir).unwrap_err(),
+        UpdateError::Invalid(_)
+    ));
+
+    // Corrupt is an error rather than "nothing staged": something wrote it.
+    std::fs::write(root.join(PENDING_FILE), "{ not json").unwrap();
+    assert!(matches!(
+        read_pending(&dir).unwrap_err(),
+        UpdateError::Parse(_)
+    ));
+}
+
+#[test]
+fn a_version_that_is_not_a_bare_filename_is_never_a_directory() {
+    let dir = temp_dir("bad-version");
+    let (stub, mut update) = good_bundle();
+    update.manifest.version = "../../../plugins".into();
+
+    let error = stage(&stub, &update, &dir, now()).unwrap_err();
+    assert!(
+        matches!(&error, UpdateError::Invalid(m) if m.contains("directory name")),
+        "{error:?}"
+    );
+}

--- a/packages/mbrc-release/tests/support/mod.rs
+++ b/packages/mbrc-release/tests/support/mod.rs
@@ -1,0 +1,108 @@
+//! Shared test scaffolding: the stub that stands in for WinHTTP.
+//!
+//! Each integration test binary compiles this module separately and uses part of
+//! it, so anything the *other* binary needs looks unused from here.
+#![allow(dead_code)]
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+use mbrc_release::{HttpClient, HttpResponse, Result, TrustedKey, UpdateError};
+
+/// The committed test key, lifted from `tests/keys/test.pub`. The release keys
+/// never sign anything a test can produce, so every test that drives a check
+/// end to end passes this as the trust list.
+pub const TEST_KEYS: &[TrustedKey] = &[TrustedKey {
+    name: "test",
+    base64: "RWT+ztjSHP1aBowOy75aVsw0jf2Vn6MMbzuTIAPRaN5EWVPjPU9fjwAj",
+}];
+
+/// An [`HttpClient`] serving canned bodies, counting requests, and able to
+/// answer 304.
+///
+/// Interior mutability because [`HttpClient::get`] takes `&self` - the real
+/// client has no reason to need `&mut`, and the stub should not distort the
+/// trait to suit itself.
+#[derive(Default)]
+pub struct StubHttp {
+    routes: RefCell<HashMap<String, Vec<u8>>>,
+    requests: RefCell<Vec<String>>,
+    not_modified: RefCell<bool>,
+}
+
+impl StubHttp {
+    /// The `ETag` the stub returns for every body it serves.
+    pub const ETAG: &'static str = "\"stub-etag\"";
+
+    pub fn serve(&self, url: &str, body: &[u8]) {
+        self.routes
+            .borrow_mut()
+            .insert(url.to_owned(), body.to_vec());
+    }
+
+    /// Answer every conditional request with 304 from now on.
+    pub fn reply_not_modified(&self) {
+        *self.not_modified.borrow_mut() = true;
+    }
+
+    pub fn request_count(&self) -> usize {
+        self.requests.borrow().len()
+    }
+
+    pub fn requested(&self, url: &str) -> bool {
+        self.requests.borrow().iter().any(|r| r == url)
+    }
+
+    /// Serves a GitHub release document at `api_base` whose assets point at the
+    /// manifest, the signature, and the zip for `version`.
+    pub fn serve_release(&self, api_base: &str, endpoint: &str, version: &str) {
+        let document = format!(
+            r#"{{
+              "tag_name": "v{version}",
+              "assets": [
+                {{ "name": "manifest.json", "browser_download_url": "https://assets.test/manifest.json" }},
+                {{ "name": "manifest.json.minisig", "browser_download_url": "https://assets.test/manifest.json.minisig" }},
+                {{ "name": "musicbee_remote_{version}.zip", "browser_download_url": "https://assets.test/musicbee_remote_{version}.zip" }}
+              ]
+            }}"#
+        );
+        self.serve(&format!("{api_base}/{endpoint}"), document.as_bytes());
+    }
+}
+
+impl HttpClient for StubHttp {
+    fn get(&self, url: &str, etag: Option<&str>) -> Result<HttpResponse> {
+        self.requests.borrow_mut().push(url.to_owned());
+
+        if etag.is_some() && *self.not_modified.borrow() {
+            return Ok(HttpResponse {
+                status: 304,
+                etag: None,
+                body: Vec::new(),
+            });
+        }
+
+        match self.routes.borrow().get(url) {
+            Some(body) => Ok(HttpResponse {
+                status: 200,
+                etag: Some(Self::ETAG.to_owned()),
+                body: body.clone(),
+            }),
+            None => Ok(HttpResponse {
+                status: 404,
+                etag: None,
+                body: Vec::new(),
+            }),
+        }
+    }
+}
+
+/// A client that fails at the transport layer, the way a machine with no route
+/// out does.
+pub struct OfflineHttp;
+
+impl HttpClient for OfflineHttp {
+    fn get(&self, _url: &str, _etag: Option<&str>) -> Result<HttpResponse> {
+        Err(UpdateError::Network("the network is unreachable".into()))
+    }
+}


### PR DESCRIPTION
Part of #149 (epic #24). This is **PR A**: everything above the `HttpClient` trait, so
all of it is tested on any host against a stub. **PR B** is the WinHTTP implementation
of that one trait, which has to be written and run on Windows against a real network.

## What lands

`mbrc-release` gains the client side, behind a `client` feature that is on by default
and off for `mbrc-helper` - an elevated exe should carry the manifest verifier and
nothing more.

| file | what it does |
|---|---|
| `version.rs` | normalizes versions to comparable semver |
| `http.rs` | `HttpClient` trait + `HttpResponse`. The whole seam |
| `check.rs` | fetch release, verify signature, compare, interval / skip / ETag / backoff |
| `stage.rs` | download, verify, extract the allowlist, write `pending.json` last |
| `state.rs` | `update_state.json` |

Plus `Config` fields, and `mbrc-buildinfo`, a build-script helper that reads
`<VersionPrefix>` from `Directory.Build.props` so the core and the helper stamp the
product version from the one place it is bumped rather than two copies of the parser.

## Versions: three components, not four

`QueryType::PluginVersion` returns a .NET `System.Version.ToString()` - `"1.5.0.0"` -
which `semver` refuses outright. Only major.minor.patch has ever been meaningful in
this project, so normalizing drops the revision rather than losing anything. Prerelease
suffixes survive, which is what makes nightly ordering semver's problem instead of
ours: `1.7.0-nightly.20260804` sits below `1.7.0` and above `1.6.0`, so a nightly user
is offered the release it is a prerelease of and never an older stable.

## Elevation and containment

Staging runs unelevated, but the helper later copies what it writes while elevated, so
the boundaries are explicit rather than incidental:

- **One directory, derived not supplied.** Everything lands under
  `<storage>/updates/<version>/`. No caller passes a destination in, and no value from
  the manifest or the archive becomes a path segment without being checked as a bare
  filename first - the version included.
- **Nothing is followed.** The staging directories are refused if they exist as
  symlinks or junctions, so a reparse point planted in `%APPDATA%` cannot aim the
  unelevated write, or the elevated copy after it, somewhere neither of us chose.
- **One bad entry name fails the whole archive.** CI produces a flat zip; anything else
  means the bytes are not what the manifest describes. Safe-but-unlisted entries
  (`LICENSE`) are simply never extracted - extraction is driven by the manifest
  allowlist, not by walking the archive.
- **`pending.json` contains no paths.** It names a version. The helper derives the
  storage directory itself and re-checks that the version is a bare filename before
  joining it (#151), so a tampered marker can name a directory that does not exist but
  cannot name one outside the staging root.
- **Staging-time verification is not apply-time verification.** The signed
  `manifest.json` and its `.minisig` are staged alongside the payload so the helper
  re-verifies from those rather than trusting anything we tell it.

The bare-filename rule (shared by the manifest parser and the extractor) also now
rejects Windows device names (`nul`, `com1.dll`), trailing dots and spaces, `:` streams,
wildcards, and control characters. Those all stay inside the directory but do not name
the file they appear to.

## `update_state.json`, not `core_settings.json`

`last_check`, the cached ETag and the skipped version are machine-written state, not
preferences, and they now live in their own file. Keeping them out of the settings file
is also what stops a save from the Configure panel un-skipping a release - the
merge-on-write fix in #157 covers the same class of bug from the other side.

## Tests

58 in `mbrc-release` (14 unit + 12 check + 12 manifest + 10 stage + 11 verify), all
against a stub client, all on Linux and Windows:

- version ordering across stable and nightly, including that a nightly is never offered
  an older stable, and the four-component form comparing equal to the three
- a 304 costs one request and re-verifies nothing; the ETag survives it
- interval suppression, "Check now" overriding it, skip-version, failure backoff
- a tampered manifest never reaches the version comparison
- staging refuses unlisted-unsafe entries, hash mismatches, truncated downloads and a
  manifest listing a file the zip lacks - and writes nothing at all in each case
- `pending.json` contains no path, and a marker naming one is refused when read back

`cargo test --workspace` green on the host and on `i686-pc-windows-msvc`;
`cargo fmt --all --check` and `clippy --all-targets -D warnings` clean.

## Deliberately not here

- **`abi_version` / `min_musicbee_build` gating.** A bundle ships both DLLs together, so
  its ABI is consistent by construction, and refusing an update for bumping the ABI
  would block exactly the updates that need to ship. The MusicBee build gate belongs
  where the MusicBee version is known, which is the panel (#152).
- **Anything that calls this.** There is no production `HttpClient` until PR B, and no
  button or schedule until #152. `mbrc_core::updates` is the seam they will use.
