### PR TITLE
feat(update): elevate and launch the staged helper from the core (#151)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -200,6 +200,29 @@ MusicBee is relaunched **through Explorer**, not as a child of the helper. A chi
 would inherit elevation and run MusicBee as administrator for the rest of the
 session, writing its settings and cache as the wrong user.
 
+### Getting there: `mbrc_apply_staged_update()`
+
+The panel calls one FFI export that takes **no arguments**. The storage directory
+comes from the initialized core, the plugins directory is where `mbrc_core.dll`
+was loaded from (asked of the loader, so it is true by construction), MusicBee is
+the current process, and the pid is our own. A caller that could name the
+directory to overwrite would be a caller worth attacking; there is nothing to
+pass, so there is nothing to tamper with.
+
+Before launching, the core verifies the **staged** helper against the staged
+signed manifest. That copy is what runs, never the installed one: a release
+replaces `mbrc-helper.exe` too, and a running image cannot overwrite itself. It
+runs elevated out of a user-writable directory, so checking it before *execution*
+- earlier than the check it then performs on the DLLs - is the boundary.
+
+Elevation is requested with `ShellExecuteExW` and the `runas` verb, chosen by
+probing whether the plugins directory is writable (by writing, not by reading an
+ACL). The prompt therefore appears while the user is still looking at the button
+they pressed. Declining it comes back as `ERROR_CANCELLED` and is reported as a
+normal outcome with the staged download intact - the concrete gain over letting
+the helper self-elevate, where the prompt would arrive after MusicBee had already
+exited and there would be no UI left to report into.
+
 ## Signing
 
 minisign (ed25519). Authenticode was rejected on cost, and GPG on the verifier

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -52,6 +52,21 @@ time = { workspace = true }
 if-addrs = { workspace = true }
 socket2 = "=0.6.4"
 
+# ShellExecuteExW (the elevation prompt for the update helper) and the loader
+# calls that answer "which directory was this DLL loaded from", which is how the
+# plugins directory is derived rather than taken from the caller. `windows-sys`
+# and not `windows`: flat C API, no COM.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "=0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_System_LibraryLoader",
+    # SHELLEXECUTEINFOW carries an HKEY field, so the struct lives behind the
+    # registry feature even though nothing here touches the registry.
+    "Win32_System_Registry",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
+
 [build-dependencies]
 mbrc-buildinfo = { workspace = true }
 csbindgen = "=1.9.8"

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -33,6 +33,31 @@ pub enum MbrcResult {
     AbiVersionMismatch = -9,
 }
 
+/// What happened when the panel asked for a staged update to be applied.
+///
+/// Its own enum rather than more [`MbrcResult`] variants: every value here is a
+/// distinct thing to *tell the user*, and only one of them is an error. In
+/// particular `Cancelled` is a normal outcome - the user declined the elevation
+/// prompt, the staged download is untouched, and pressing the button again is
+/// the obvious next move.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateLaunch {
+    /// The helper was started. MusicBee is expected to exit next; the helper is
+    /// waiting for exactly that.
+    Launched = 0,
+    /// No update is staged, so there was nothing to apply.
+    NothingStaged = 1,
+    /// The user declined the elevation prompt.
+    Cancelled = 2,
+    /// The staged helper is not what the release signed. Nothing was started,
+    /// and this is the one outcome that should be reported loudly: it means the
+    /// staged bundle was tampered with after it was downloaded.
+    VerifyFailed = 3,
+    /// Something else went wrong; the detail is in the log.
+    Failed = 4,
+}
+
 /// Notifications forwarded from MusicBee via `Plugin.ReceiveNotification`.
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -25,7 +25,8 @@ use std::sync::Arc;
 
 use crate::ffi::callbacks::SafeCallbacks;
 use crate::ffi::types::{
-    HostCommandType, HostQueryType, MbrcCallbacks, MbrcResult, NotificationType, MBRC_ABI_VERSION,
+    HostCommandType, HostQueryType, MbrcCallbacks, MbrcResult, NotificationType, UpdateLaunch,
+    MBRC_ABI_VERSION,
 };
 use crate::providers::{FfiProviders, Providers};
 
@@ -302,6 +303,30 @@ pub unsafe extern "C" fn mbrc_set_log_level(directive: *const c_char) -> c_int {
         match logging::set_level(&directive) {
             Ok(()) => MbrcResult::Ok as c_int,
             Err(_) => MbrcResult::InvalidArgument as c_int,
+        }
+    })
+}
+
+/// Apply the staged update: verify the staged helper, elevate if the plugins
+/// directory needs it, and start the helper.
+///
+/// Takes nothing, deliberately. The storage directory comes from the initialized
+/// core, the plugins directory is where this DLL was loaded from, MusicBee is
+/// this process, and the pid is our own. A caller that could name the directory
+/// to overwrite would be a caller worth attacking; there is nothing to pass, so
+/// there is nothing to tamper with.
+///
+/// Returns an [`UpdateLaunch`] value. `Launched` means the helper is up and
+/// waiting for MusicBee to exit - the caller is expected to shut MusicBee down
+/// next. `Cancelled` (the user declined elevation) is a normal outcome and
+/// leaves the staged update in place for a retry.
+#[no_mangle]
+pub extern "C" fn mbrc_apply_staged_update() -> c_int {
+    ffi_guard("mbrc_apply_staged_update", || match state::storage_path() {
+        Some(storage) => updates::elevate::launch(&storage) as c_int,
+        None => {
+            tracing::error!("cannot apply an update before the core is initialized");
+            UpdateLaunch::Failed as c_int
         }
     })
 }

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -158,16 +158,7 @@ pub fn read_settings_bytes() -> Option<Vec<u8>> {
 /// `Config` would reset every field it omits back to its default - so saving the
 /// panel would silently wipe any Rust-only setting.
 pub fn write_settings_bytes(bytes: &[u8]) -> Result<(), String> {
-    let storage = {
-        let guard = lock();
-        guard
-            .as_ref()
-            .ok_or("core not initialized")?
-            .core
-            .config
-            .storage_path
-            .clone()
-    };
+    let storage = storage_path().ok_or("core not initialized")?;
     let patch: serde_json::Value =
         rmp_serde::from_slice(bytes).map_err(|e| format!("invalid settings msgpack: {e}"))?;
     let mut config = merge_settings(Config::load(&storage), &patch)?;
@@ -176,6 +167,14 @@ pub fn write_settings_bytes(bytes: &[u8]) -> Result<(), String> {
     let pretty = serde_json::to_string_pretty(&config).map_err(|e| e.to_string())?;
     let path = std::path::Path::new(&storage).join("core_settings.json");
     std::fs::write(&path, pretty).map_err(|e| format!("write settings: {e}"))
+}
+
+/// The storage directory MusicBee handed the core at init, or `None` before
+/// then. The one place that answer lives, so nothing has to be told it twice.
+pub fn storage_path() -> Option<String> {
+    lock()
+        .as_ref()
+        .map(|state| state.core.config.storage_path.clone())
 }
 
 /// Apply the host's settings payload over `base`, field by field.

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -243,6 +243,11 @@ fn spawn(exe: &Path, arguments: &[String], _elevate: bool) -> UpdateLaunch {
 
 /// Joins arguments into a command line, quoting each.
 ///
+/// Only the Windows launch path builds a command line - off Windows the
+/// arguments go to `Command::args` as a list - so this reads as dead code there
+/// while its test still runs, which is the point of keeping it compiled.
+#[cfg_attr(not(windows), allow(dead_code))]
+///
 /// Every argument here is either a literal or a path we derived, so this is not
 /// trying to be a general Windows quoting routine - it is making sure a path
 /// with a space in it (`C:\Program Files\...`, which is the common case) arrives

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -1,0 +1,340 @@
+//! Handing a staged update to the elevated helper.
+//!
+//! The panel presses a button; this decides whether elevation is needed, proves
+//! the helper it is about to run is the one the release signed, and launches it.
+//!
+//! Three things here are not arbitrary:
+//!
+//! - **Nothing is taken from the caller.** The plugins directory is where this
+//!   very DLL was loaded from, MusicBee is this process, and the pid is our own.
+//!   A panel that could name the directory to overwrite would be a panel worth
+//!   attacking; there is nothing to pass, so there is nothing to tamper with.
+//! - **The staged helper is verified before it is *executed*.** It runs elevated
+//!   out of a user-writable directory, so its signature check is the security
+//!   boundary, and it lands earlier than the check the helper does on the DLLs.
+//!   The installed helper cannot be used instead: a release replaces
+//!   `mbrc-helper.exe` too, and a running image cannot overwrite itself.
+//! - **Elevation is asked for now, not later.** `runas` prompts while the user is
+//!   still looking at the button they pressed. If the helper self-elevated after
+//!   MusicBee had exited, a declined prompt would leave a closed MusicBee, no UI,
+//!   and nothing to report the cancellation into.
+
+use std::path::{Path, PathBuf};
+
+use mbrc_release::{stage::STAGING_DIR, verify_bundled_file, verify_manifest, Manifest};
+
+use crate::ffi::types::UpdateLaunch;
+
+/// The helper, as named in the manifest and staged beside the DLLs.
+const HELPER_EXE: &str = "mbrc-helper.exe";
+const MANIFEST_ASSET: &str = "manifest.json";
+const SIGNATURE_ASSET: &str = "manifest.json.minisig";
+
+/// Verifies the staged bundle's helper and launches it, elevating if the plugins
+/// directory is not writable as we stand.
+///
+/// Returns the outcome the panel reports; the detail goes to the log, because a
+/// UI that has to render every failure mode is a UI that renders none of them
+/// well.
+pub fn launch(storage_path: &str) -> UpdateLaunch {
+    let pending = match mbrc_release::read_pending(storage_path) {
+        Ok(Some(pending)) => pending,
+        Ok(None) => return UpdateLaunch::NothingStaged,
+        Err(e) => {
+            tracing::warn!(error = %e, "the staged-update marker is unreadable");
+            return UpdateLaunch::NothingStaged;
+        }
+    };
+
+    let staged = Path::new(storage_path)
+        .join(STAGING_DIR)
+        .join(&pending.version);
+    let helper = match verified_helper(&staged) {
+        Ok(helper) => helper,
+        Err(e) => {
+            tracing::error!(error = %e, version = %pending.version, "refusing to run the staged helper");
+            return UpdateLaunch::VerifyFailed;
+        }
+    };
+
+    let target = match plugins_dir() {
+        Some(dir) => dir,
+        None => {
+            tracing::error!("could not determine the plugins directory");
+            return UpdateLaunch::Failed;
+        }
+    };
+    let relaunch = match std::env::current_exe() {
+        Ok(exe) => exe,
+        Err(e) => {
+            tracing::error!(error = %e, "could not determine the MusicBee executable");
+            return UpdateLaunch::Failed;
+        }
+    };
+
+    let elevate = !is_writable(&target);
+    tracing::info!(
+        version = %pending.version,
+        helper = %helper.display(),
+        target = %target.display(),
+        elevate,
+        "launching the update helper"
+    );
+
+    spawn(&helper, &arguments(&staged, &target, &relaunch), elevate)
+}
+
+/// The staged helper, once the release signature says it is the right bytes.
+///
+/// Verified from the *staged* manifest and signature, not from anything the core
+/// remembers about the download: the point is to check the file that is about to
+/// run as administrator, now, in the state it is in on disk.
+fn verified_helper(staged: &Path) -> Result<PathBuf, String> {
+    let manifest_bytes =
+        std::fs::read(staged.join(MANIFEST_ASSET)).map_err(|e| format!("{MANIFEST_ASSET}: {e}"))?;
+    let signature = std::fs::read_to_string(staged.join(SIGNATURE_ASSET))
+        .map_err(|e| format!("{SIGNATURE_ASSET}: {e}"))?;
+    let (manifest, key) =
+        verify_manifest(&manifest_bytes, &signature).map_err(|e| e.to_string())?;
+
+    let helper = staged.join(HELPER_EXE);
+    let bytes = std::fs::read(&helper).map_err(|e| format!("{HELPER_EXE}: {e}"))?;
+    verify_bundled_file(&manifest, HELPER_EXE, &bytes).map_err(|e| e.to_string())?;
+    log_verified(&manifest, key);
+    Ok(helper)
+}
+
+fn log_verified(manifest: &Manifest, key: &str) {
+    tracing::info!(
+        version = %manifest.version,
+        key,
+        "the staged helper matches the signed manifest"
+    );
+}
+
+/// `update --pid <us> --staged <dir> --target <dir> --relaunch <exe>`.
+fn arguments(staged: &Path, target: &Path, relaunch: &Path) -> Vec<String> {
+    vec![
+        "update".into(),
+        "--pid".into(),
+        std::process::id().to_string(),
+        "--staged".into(),
+        staged.display().to_string(),
+        "--target".into(),
+        target.display().to_string(),
+        "--relaunch".into(),
+        relaunch.display().to_string(),
+    ]
+}
+
+/// Whether this process can write to `dir`, tested by writing rather than by
+/// reading an ACL: the question is what the filesystem will let us do, and
+/// UAC virtualization and inherited denies make the ACL a poor predictor.
+fn is_writable(dir: &Path) -> bool {
+    let probe = dir.join(".mbrc-write-probe");
+    match std::fs::write(&probe, b"") {
+        Ok(()) => {
+            let _ = std::fs::remove_file(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// The directory this DLL was loaded from, which is MusicBee's plugins
+/// directory. Asked of the loader rather than assembled from a MusicBee path:
+/// this is the one answer that is true by construction.
+#[cfg(windows)]
+fn plugins_dir() -> Option<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::HMODULE;
+    use windows_sys::Win32::System::LibraryLoader::{
+        GetModuleFileNameW, GetModuleHandleExW, GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+        GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+    };
+
+    let mut module: HMODULE = std::ptr::null_mut();
+    // SAFETY: the address is of a function in this DLL, which is what the
+    // FROM_ADDRESS flag expects; UNCHANGED_REFCOUNT means no handle to release.
+    let ok = unsafe {
+        GetModuleHandleExW(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            plugins_dir as *const u16,
+            &mut module,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+
+    let mut buffer = [0u16; 32_768];
+    // SAFETY: `module` is a live module handle and the buffer length is its real
+    // length in units.
+    let len = unsafe { GetModuleFileNameW(module, buffer.as_mut_ptr(), buffer.len() as u32) };
+    if len == 0 || len as usize >= buffer.len() {
+        return None;
+    }
+
+    let path = PathBuf::from(std::ffi::OsString::from_wide(&buffer[..len as usize]));
+    path.parent().map(Path::to_path_buf)
+}
+
+#[cfg(not(windows))]
+fn plugins_dir() -> Option<PathBuf> {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+}
+
+/// Starts the helper, with an elevation prompt when `elevate` is set.
+///
+/// `runas` is what produces the UAC prompt. A declined prompt comes back as
+/// `ERROR_CANCELLED`, which is a distinct outcome rather than a failure: the
+/// staged download is untouched and the user can press the button again.
+#[cfg(windows)]
+fn spawn(exe: &Path, arguments: &[String], elevate: bool) -> UpdateLaunch {
+    use windows_sys::Win32::Foundation::{GetLastError, ERROR_CANCELLED};
+    use windows_sys::Win32::UI::Shell::{ShellExecuteExW, SEE_MASK_NOASYNC, SHELLEXECUTEINFOW};
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    let verb = wide(if elevate { "runas" } else { "open" });
+    let file = wide(&exe.display().to_string());
+    let parameters = wide(&quote(arguments));
+
+    let mut info: SHELLEXECUTEINFOW = unsafe { std::mem::zeroed() };
+    info.cbSize = size_of::<SHELLEXECUTEINFOW>() as u32;
+    // NOASYNC because this process is about to be asked to exit: the shell must
+    // finish launching before we can go away.
+    info.fMask = SEE_MASK_NOASYNC;
+    info.lpVerb = verb.as_ptr();
+    info.lpFile = file.as_ptr();
+    info.lpParameters = parameters.as_ptr();
+    info.nShow = SW_SHOWNORMAL;
+
+    // SAFETY: every pointer in `info` is a null-terminated wide string that
+    // outlives the call, and `cbSize` is the struct's real size.
+    let ok = unsafe { ShellExecuteExW(&mut info) };
+    if ok != 0 {
+        return UpdateLaunch::Launched;
+    }
+
+    // SAFETY: no pointers; reads the calling thread's code.
+    match unsafe { GetLastError() } {
+        ERROR_CANCELLED => {
+            tracing::info!("the user declined the elevation prompt");
+            UpdateLaunch::Cancelled
+        }
+        code => {
+            tracing::error!(code, "ShellExecuteExW failed");
+            UpdateLaunch::Failed
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn spawn(exe: &Path, arguments: &[String], _elevate: bool) -> UpdateLaunch {
+    // No elevation model to speak of here, and no MusicBee either. Kept so the
+    // module compiles and its tests run on the Linux CI runner.
+    match std::process::Command::new(exe).args(arguments).spawn() {
+        Ok(_) => UpdateLaunch::Launched,
+        Err(_) => UpdateLaunch::Failed,
+    }
+}
+
+/// Joins arguments into a command line, quoting each.
+///
+/// Every argument here is either a literal or a path we derived, so this is not
+/// trying to be a general Windows quoting routine - it is making sure a path
+/// with a space in it (`C:\Program Files\...`, which is the common case) arrives
+/// as one argument.
+fn quote(arguments: &[String]) -> String {
+    arguments
+        .iter()
+        .map(|a| format!("\"{}\"", a.replace('"', "\\\"")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(windows)]
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nothing_staged_is_not_a_failure() {
+        let dir = std::env::temp_dir().join("mbrc-elevate-empty");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(
+            launch(&dir.to_string_lossy()),
+            UpdateLaunch::NothingStaged,
+            "an empty storage directory means there is nothing to apply"
+        );
+    }
+
+    #[test]
+    fn a_staged_bundle_the_release_keys_do_not_trust_is_refused() {
+        // The marker says something is staged, the bundle is not signed by a
+        // release key, and nothing is launched. This is the check that matters:
+        // the file is about to run as administrator.
+        let dir = std::env::temp_dir().join("mbrc-elevate-untrusted");
+        let _ = std::fs::remove_dir_all(&dir);
+        let staged = dir.join(STAGING_DIR).join("9.9.9");
+        std::fs::create_dir_all(&staged).unwrap();
+        std::fs::write(
+            dir.join(STAGING_DIR).join("pending.json"),
+            r#"{"schema":1,"version":"9.9.9","staged_at":"2026-08-15T00:00:00Z","files":[]}"#,
+        )
+        .unwrap();
+        std::fs::write(staged.join(MANIFEST_ASSET), "{}").unwrap();
+        std::fs::write(staged.join(SIGNATURE_ASSET), "not a signature").unwrap();
+        std::fs::write(staged.join(HELPER_EXE), b"not the helper").unwrap();
+
+        assert_eq!(launch(&dir.to_string_lossy()), UpdateLaunch::VerifyFailed);
+    }
+
+    #[test]
+    fn arguments_name_this_process_and_the_derived_paths() {
+        let args = arguments(
+            Path::new("C:/storage/updates/1.6.0"),
+            Path::new("C:/Program Files/MusicBee/Plugins"),
+            Path::new("C:/Program Files/MusicBee/MusicBee.exe"),
+        );
+        assert_eq!(args[0], "update");
+        assert_eq!(args[2], std::process::id().to_string());
+        // The helper parses `--flag value` pairs and rejects anything else, so
+        // the shape matters as much as the values.
+        assert_eq!(args.len(), 9);
+        for flag in ["--pid", "--staged", "--target", "--relaunch"] {
+            assert!(args.iter().any(|a| a == flag), "{flag} is missing");
+        }
+    }
+
+    #[test]
+    fn a_path_with_spaces_stays_one_argument() {
+        let line = quote(&[
+            "--target".into(),
+            "C:\\Program Files\\MusicBee\\Plugins".into(),
+        ]);
+        assert_eq!(
+            line,
+            "\"--target\" \"C:\\Program Files\\MusicBee\\Plugins\""
+        );
+    }
+
+    #[test]
+    fn writability_is_tested_by_writing() {
+        let dir = std::env::temp_dir().join("mbrc-elevate-writable");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(is_writable(&dir));
+        // And the probe does not survive the question being asked.
+        assert!(std::fs::read_dir(&dir).unwrap().next().is_none());
+
+        assert!(!is_writable(&dir.join("does-not-exist")));
+    }
+}

--- a/packages/mbrc-core/src/updates/mod.rs
+++ b/packages/mbrc-core/src/updates/mod.rs
@@ -10,6 +10,8 @@
 //! production one (WinHTTP) from the user's settings, and the panel and the
 //! background schedule that call in arrive with the UI (#152).
 
+pub mod elevate;
+
 use mbrc_release::{
     check::{self, CheckOptions, CheckOutcome},
     stage, AvailableUpdate, HttpClient, Result, StagedUpdate, UpdateState,

--- a/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
@@ -136,6 +136,24 @@ namespace MusicBeePlugin.Ffi.Generated
         internal static extern int mbrc_set_log_level(byte* directive);
 
         /// <summary>
+        ///  Apply the staged update: verify the staged helper, elevate if the plugins
+        ///  directory needs it, and start the helper.
+        ///
+        ///  Takes nothing, deliberately. The storage directory comes from the initialized
+        ///  core, the plugins directory is where this DLL was loaded from, MusicBee is
+        ///  this process, and the pid is our own. A caller that could name the directory
+        ///  to overwrite would be a caller worth attacking; there is nothing to pass, so
+        ///  there is nothing to tamper with.
+        ///
+        ///  Returns an [`UpdateLaunch`] value. `Launched` means the helper is up and
+        ///  waiting for MusicBee to exit - the caller is expected to shut MusicBee down
+        ///  next. `Cancelled` (the user declined elevation) is a normal outcome and
+        ///  leaves the staged update in place for a retry.
+        /// </summary>
+        [DllImport(__DllName, EntryPoint = "mbrc_apply_staged_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        internal static extern int mbrc_apply_staged_update();
+
+        /// <summary>
         ///  Free a string previously returned to C# by the core. Null-safe. This is the
         ///  only Rust-owned allocation the C# side frees through us.
         ///

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -19,6 +19,15 @@ namespace MusicBeePlugin.Ffi.Generated
         AbiVersionMismatch = -9,
     }
 
+    public enum UpdateLaunch
+    {
+        Launched = 0,
+        NothingStaged = 1,
+        Cancelled = 2,
+        VerifyFailed = 3,
+        Failed = 4,
+    }
+
     public enum NotificationType
     {
         TrackChanged = 0,

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -275,6 +275,32 @@ namespace MusicBeePlugin.Ffi
         }
 
         /// <summary>
+        ///     Ask the core to apply a staged update: it verifies the staged helper,
+        ///     prompts for elevation if the plugins directory needs it, and starts
+        ///     the helper, which waits for MusicBee to exit before swapping files.
+        ///     Takes no arguments by design - every path is derived inside the core,
+        ///     so there is nothing here that could name a directory to overwrite.
+        ///     On <see cref="UpdateLaunch.Launched" /> the caller is expected to shut
+        ///     MusicBee down; <see cref="UpdateLaunch.Cancelled" /> means the user
+        ///     declined the prompt and the staged update is still there to retry.
+        /// </summary>
+        public UpdateLaunch ApplyStagedUpdate()
+        {
+            if (!_initialized) return UpdateLaunch.Failed;
+            try
+            {
+                var result = (UpdateLaunch)NativeMethods.mbrc_apply_staged_update();
+                _logger.Info("Update launch result: {0}", result);
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to launch the update helper");
+                return UpdateLaunch.Failed;
+            }
+        }
+
+        /// <summary>
         ///     Persist new settings to the Rust core (which validates then writes
         ///     core_settings.json). Returns false if the core rejected them.
         /// </summary>


### PR DESCRIPTION
PR B of #151, and the half that completes it. PR A (#161) built
`mbrc-helper update`; this is what calls it.

Closes #151.

## The export

`mbrc_apply_staged_update()` - **no arguments**, deliberately:

| what | where it comes from |
|---|---|
| storage directory | the initialized core (`state::storage_path()`) |
| plugins directory | where `mbrc_core.dll` was loaded from, via `GetModuleHandleExW(FROM_ADDRESS)` |
| MusicBee executable | `current_exe()` - the core is loaded into it |
| pid | our own |

A caller that could name the directory to overwrite would be a caller worth
attacking. There is nothing to pass, so there is nothing to tamper with. The C#
side is a five-line wrapper (`NativeBridge.ApplyStagedUpdate`) returning the
generated `UpdateLaunch` enum; the UI that calls it is #152.

## The staged helper is verified before it is *executed*

Not merely before it is copied. It runs elevated out of a user-writable
directory, so that check is the security boundary, and it lands earlier than the
re-verification the helper then does on the DLLs.

The staged copy is also the only one that can do the job: a release replaces
`mbrc-helper.exe` too, and a running image cannot be overwritten on Windows.

## Elevation

`ShellExecuteExW` with `runas` when the plugins directory is not writable, `open`
when it is. Writability is decided **by writing** a probe file rather than by
reading an ACL - UAC virtualization and inherited denies make the ACL a poor
predictor of what the filesystem will actually allow.

The prompt therefore appears while the user is still looking at the button they
pressed. `ERROR_CANCELLED` maps to `UpdateLaunch::Cancelled`, a normal outcome
with the staged download left intact for a retry - the concrete gain over letting
the helper self-elevate, where the prompt would land after MusicBee had exited
with no UI left to report into.

## `UpdateLaunch`

Its own `#[repr(i32)]` enum in `ffi/types.rs` (so build.rs mirrors it to C#)
rather than more `MbrcResult` variants: every value is a distinct thing to tell
the user, and only `Failed` is an error. `Cancelled` in particular is not.

`Launched` / `NothingStaged` / `Cancelled` / `VerifyFailed` / `Failed`.

## Also here

`state::storage_path()` - `write_settings_bytes` was reaching into the lock for
the same answer inline; now there is one place that knows it.

## Checks

- `cargo clippy --workspace --all-targets --target i686-pc-windows-msvc -- -D warnings` clean
- `cargo test -p mbrc-core --target i686-pc-windows-msvc`: 161 + the suites, green
- C# solution builds; generated bindings regenerated by `build.rs` and committed
  (the CI diff guard would otherwise fail)
- New tests cover: nothing staged is not a failure, a bundle the release keys do
  not trust is refused before anything launches, the argv shape matches what the
  helper's strict parser accepts, a path with spaces survives quoting, and the
  writability probe cleans up after itself

## Still untested by machine

The two end-to-end items in #151's acceptance list - a real Program Files install
and a release that bumps the helper itself - need a signed release to exist. They
are worth doing by hand once #152 gives the panel a button, and I have not
pretended otherwise here.
