### PR TITLE
feat(update): offer updates from the Configure panel (#152)

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -79,6 +79,14 @@ nightly order correctly: `1.7.0-nightly.20260804` is below `1.7.0` and above
 `1.6.0`, so a nightly user is offered the release it is a prerelease of and never
 an older stable.
 
+**Automatic checking is opt-in.** `update_check_enabled` defaults to *off*: a
+check is an unprompted outbound request to github.com, so making one is the
+user's decision. When it is on, the core runs exactly one check per session, a
+minute after networking starts - late enough that the library reconcile and the
+cover-cache build have the machine to themselves first. The panel's "Check now"
+button forces a check regardless of the setting and regardless of the interval;
+never being able to ask would be the other way to get this wrong.
+
 Checks are rate-limited by an interval (24 hours by default) and by an `ETag`:
 the release document is requested with `If-None-Match`, and a `304` ends the
 check without downloading or verifying anything. GitHub allows 60 unauthenticated
@@ -222,6 +230,66 @@ they pressed. Declining it comes back as `ERROR_CANCELLED` and is reported as a
 normal outcome with the staged download intact - the concrete gain over letting
 the helper self-elevate, where the prompt would arrive after MusicBee had already
 exited and there would be no UI left to report into.
+
+## The panel
+
+The Configure dialog's Updates group is the whole user-facing surface: a status
+line, one action button, and a "Check for updates automatically" checkbox.
+
+The core owns the state machine (`updates::service`) and the panel renders it.
+Check, download and skip are fire-and-forget host commands that start a
+background thread, so nothing the user presses blocks MusicBee's UI thread on a
+network request; the status comes back through the `UpdateStatus` host query and
+an `UpdateStatusChanged` push event.
+
+| `state` | the button offers |
+|---|---|
+| `unknown` / `up_to_date` / `skipped` / `disabled` / `error` | Check now |
+| `available` | Download |
+| `download_failed` | Retry download |
+| `downloading` / `checking` | nothing (disabled) |
+| `staged` | Install and restart |
+
+A failed *check* renders as "No update could be found", not as the underlying
+diagnostic: an unreachable host, a release without a manifest, and a signature
+that did not verify all leave the user with the same next move, and the core has
+already written the real reason to `mbrc-core.log`. A failed *download* is a
+separate state precisely so it does not say that - the update is known, named,
+and worth retrying.
+
+Three rules that are not obvious from the table:
+
+- **One job at a time.** A check and a download both talk to github.com and both
+  write the same status. A second request while one runs is refused, not queued.
+- **A check with no news changes nothing.** A `304` (the release document is
+  unchanged since the cached `ETag`) and a not-due check are not answers, so they
+  neither rewrite the status nor discard the verified update behind an offer.
+  Without that, pressing "Check now" twice would retract the Download button the
+  first press produced - the second request is a `304` almost every time.
+- **A staged bundle outlives a later check.** If a check cannot reach GitHub at
+  all, the status stays `staged`, with the failure carried alongside as a
+  message. Losing the restart button would strand a download the user has already
+  approved.
+- **The download is never named by the host.** `DownloadUpdate` fetches the
+  update the core's own verified check produced, or is refused. There is no
+  parameter to point it somewhere else.
+
+`min_musicbee_build` is enforced here rather than in the check, because the core
+cannot see MusicBee's version and the panel can: it reads the build from
+`MusicBee.exe`'s file version - the same number the NSIS installer gates on - and
+greys out the download when the release needs a newer one.
+
+The dialog itself is fixed-size, and six groups plus the footer do not fit a 720p
+screen - nor a 1080p one at 150% scaling, which is the same thing in logical
+pixels. Its height is therefore clamped to the screen's work area and the group
+column scrolls, with the Save/Close footer docked outside the scrolling region so
+it can never end up off-screen.
+
+After `mbrc_apply_staged_update()` returns `Launched`, the panel closes MusicBee
+by posting `WM_CLOSE` to its main window, the same message its title bar sends. A
+MusicBee configured to minimize on close will not exit; the helper then times out
+after two minutes having touched nothing (exit 6), and the staged update simply
+waits for the next real exit.
 
 ## Signing
 

--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -95,8 +95,12 @@ fn default_tcp_keepalive_secs() -> u64 {
     45
 }
 
+/// Off. An automatic check is an unprompted outbound request to github.com, so
+/// it is the user's call to make, not ours to assume. The panel's "Check now"
+/// works whatever this says - never being able to ask would be the other way to
+/// get this wrong.
 fn default_update_check_enabled() -> bool {
-    true
+    false
 }
 
 fn default_update_check_interval_hours() -> u64 {
@@ -167,8 +171,9 @@ pub struct Config {
     /// the kernel detects and drops dead half-open connections.
     #[serde(default = "default_tcp_keepalive_secs")]
     pub tcp_keepalive_secs: u64,
-    /// Whether the core checks for plugin updates at all. A check is a request
-    /// to github.com, so it is a preference, and one the user can turn off.
+    /// Whether the core checks for plugin updates *on its own*. A check is a
+    /// request to github.com, so it is opt-in: this defaults to off, and the
+    /// panel's "Check now" runs regardless of it.
     #[serde(default = "default_update_check_enabled")]
     pub update_check_enabled: bool,
     /// Which release channel to follow (`stable` / `nightly`).
@@ -616,15 +621,18 @@ mod tests {
 
     #[test]
     fn update_settings_default_and_round_trip() {
-        // Defaults: checking on, stable, daily, no proxy override.
+        // Defaults: automatic checking OFF (opt-in), stable, daily, no proxy
+        // override.
         let c = Config::default();
-        assert!(c.update_check_enabled);
+        assert!(!c.update_check_enabled);
         assert_eq!(c.update_channel, UpdateChannel::Stable);
         assert_eq!(c.update_check_interval_hours, 24);
         assert!(c.proxy_override.is_empty());
 
+        // Non-default values throughout, so the round-trip proves the fields are
+        // carried rather than re-defaulted.
         let json = serde_json::to_string(&Config {
-            update_check_enabled: false,
+            update_check_enabled: true,
             update_channel: UpdateChannel::Nightly,
             update_check_interval_hours: 6,
             proxy_override: "http://proxy.local:8080".into(),
@@ -634,7 +642,7 @@ mod tests {
         assert!(json.contains("\"update_channel\":\"nightly\""), "{json}");
 
         let back: Config = serde_json::from_str(&json).unwrap();
-        assert!(!back.update_check_enabled);
+        assert!(back.update_check_enabled);
         assert_eq!(back.update_channel, UpdateChannel::Nightly);
         assert_eq!(back.update_check_interval_hours, 6);
         assert_eq!(back.proxy_override, "http://proxy.local:8080");
@@ -648,10 +656,11 @@ mod tests {
 
     #[test]
     fn an_older_settings_file_gains_the_update_defaults() {
-        // A file written before these fields existed must keep working, with
-        // checking on rather than silently off.
+        // A file written before these fields existed must keep working, and it
+        // must not start checking for updates behind the user's back: an upgrade
+        // is not consent.
         let c: Config = serde_json::from_str(r#"{"port":3000}"#).unwrap();
-        assert!(c.update_check_enabled);
+        assert!(!c.update_check_enabled);
         assert_eq!(c.update_channel, UpdateChannel::Stable);
     }
 

--- a/packages/mbrc-core/src/ffi/dtos.rs
+++ b/packages/mbrc-core/src/ffi/dtos.rs
@@ -162,6 +162,32 @@ pub struct BlockedConnection {
     pub reason: String,
 }
 
+/// Where the update flow stands, surfaced to the settings panel's Updates group
+/// (result of the `UpdateStatus` host query). A Rust -> C# *result*; the C# side
+/// reads an `UpdateStatus`. The state machine that produces it, and the
+/// `STATE_*` spellings `state` carries, live in
+/// [`crate::updates::service`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateStatus {
+    /// One of the `STATE_*` constants: `unknown`, `checking`, `up_to_date`,
+    /// `available`, `downloading`, `staged`, `skipped`, `disabled`, `error`.
+    pub state: String,
+    /// The version the state is about: the available or staged release, or the
+    /// latest published one when up to date. Empty when there is nothing to name.
+    pub version: String,
+    /// Where the release notes live, for the panel's link.
+    pub notes_url: String,
+    /// The MusicBee build the release requires. The core cannot see MusicBee's
+    /// version, so the gate is enforced by the host, which can.
+    pub min_musicbee_build: u32,
+    /// Why a check or download failed. Empty otherwise - a status line that only
+    /// ever carries errors is one the panel can render without interpreting it.
+    pub message: String,
+    /// When the last check that actually reached github.com completed (RFC3339),
+    /// or empty if none ever has.
+    pub checked_at: String,
+}
+
 /// The addresses a client can reach the server on, surfaced to the settings
 /// panel (result of the `ListeningAddresses` host query) so the user knows what
 /// to point the phone client at - the way the shipped C# 1.4.1 panel listed the

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -223,6 +223,11 @@ pub enum HostQueryType {
     /// plus the bound port. The settings panel shows these so the user knows what
     /// to point the phone at. Returns a MessagePack `ListeningInfo`.
     ListeningAddresses = 3,
+    /// Where the update flow currently stands (never checked / checking /
+    /// up to date / available / downloading / staged / failed), for the panel's
+    /// Updates group. Returns a MessagePack `UpdateStatus`. Always answers, even
+    /// before a check has ever run.
+    UpdateStatus = 4,
 }
 
 impl HostQueryType {
@@ -231,6 +236,7 @@ impl HostQueryType {
             1 => Some(Self::CacheStatus),
             2 => Some(Self::RecentBlocked),
             3 => Some(Self::ListeningAddresses),
+            4 => Some(Self::UpdateStatus),
             _ => None,
         }
     }
@@ -251,6 +257,19 @@ pub enum HostCommandType {
     RebuildCovers = 2,
     /// Clear the in-memory blocked-connection log (the panel's "Clear" button).
     ClearBlockedLog = 3,
+    /// Check github.com for a newer release, in the background. Forced: the
+    /// panel's button is a direct instruction, so it ignores both the
+    /// `update_check_enabled` preference and the interval. The result lands in
+    /// [`HostQueryType::UpdateStatus`] and raises
+    /// [`HostEventType::UpdateStatusChanged`].
+    CheckForUpdate = 4,
+    /// Download and stage the update the last check found, in the background.
+    /// Rejected unless a check has actually produced one - there is nothing the
+    /// host can name here, so it cannot ask for a different download.
+    DownloadUpdate = 5,
+    /// Record that the user does not want to be offered the currently available
+    /// version again.
+    SkipUpdate = 6,
 }
 
 impl HostCommandType {
@@ -259,6 +278,9 @@ impl HostCommandType {
             1 => Some(Self::RebuildMetadata),
             2 => Some(Self::RebuildCovers),
             3 => Some(Self::ClearBlockedLog),
+            4 => Some(Self::CheckForUpdate),
+            5 => Some(Self::DownloadUpdate),
+            6 => Some(Self::SkipUpdate),
             _ => None,
         }
     }
@@ -277,6 +299,10 @@ pub enum HostEventType {
     /// The cache status changed (a reconcile/rebuild started or finished); the
     /// settings panel should re-query [`HostQueryType::CacheStatus`].
     CacheStatusChanged = 1,
+    /// The update flow moved on (a check or a download finished); the settings
+    /// panel should re-query [`HostQueryType::UpdateStatus`]. Raised from the
+    /// background job's own thread, so the host marshals before touching UI.
+    UpdateStatusChanged = 2,
 }
 
 /// Callback table handed from C# to Rust at `mbrc_initialize`.
@@ -371,8 +397,12 @@ mod tests {
             HostQueryType::from_i32(3),
             Some(HostQueryType::ListeningAddresses)
         );
+        assert_eq!(
+            HostQueryType::from_i32(4),
+            Some(HostQueryType::UpdateStatus)
+        );
         assert_eq!(HostQueryType::from_i32(0), None);
-        assert_eq!(HostQueryType::from_i32(4), None);
+        assert_eq!(HostQueryType::from_i32(5), None);
         assert_eq!(
             HostCommandType::from_i32(1),
             Some(HostCommandType::RebuildMetadata)
@@ -385,9 +415,22 @@ mod tests {
             HostCommandType::from_i32(3),
             Some(HostCommandType::ClearBlockedLog)
         );
-        assert_eq!(HostCommandType::from_i32(4), None);
+        assert_eq!(
+            HostCommandType::from_i32(4),
+            Some(HostCommandType::CheckForUpdate)
+        );
+        assert_eq!(
+            HostCommandType::from_i32(5),
+            Some(HostCommandType::DownloadUpdate)
+        );
+        assert_eq!(
+            HostCommandType::from_i32(6),
+            Some(HostCommandType::SkipUpdate)
+        );
+        assert_eq!(HostCommandType::from_i32(7), None);
         // HostEventType is core -> host (no from_i32), but its contract value is
         // still pinned so the C# enum stays in sync.
         assert_eq!(HostEventType::CacheStatusChanged as i32, 1);
+        assert_eq!(HostEventType::UpdateStatusChanged as i32, 2);
     }
 }

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -21,6 +21,12 @@ use tokio::sync::Notify;
 
 use crate::state::Core;
 
+/// How long after networking starts the session's one update check runs. Long
+/// enough that the library reconcile and cover build have the machine to
+/// themselves first; short enough that a user who opens the panel to look finds
+/// the answer already there.
+const STARTUP_UPDATE_CHECK_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
+
 /// Handle to a running networking stack. Call [`NetHandle::stop`] to shut it
 /// down and join the server thread.
 pub struct NetHandle {
@@ -143,6 +149,21 @@ fn run_thread(
         // MusicBee calls.
         let cache_core = core.clone();
         tokio::task::spawn_blocking(move || reconcile_library(&cache_core));
+
+        // One update check per session, and only if the user asked for them.
+        // Delayed so it does not compete with the library reconcile and cover
+        // build above, which are what MusicBee was actually opened for; the
+        // interval in the settings still decides whether the check does anything
+        // once it fires. Skipped outright when the preference is off, so a staged
+        // update stays the panel's headline instead of being overwritten with
+        // "checking is disabled".
+        if core.config.update_check_enabled {
+            let update_core = core.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(STARTUP_UPDATE_CHECK_DELAY).await;
+                crate::updates::service::start_check(update_core, false);
+            });
+        }
 
         tokio::select! {
             _ = accept_loop(listener, core.clone()) => {}

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -169,6 +169,18 @@ pub fn write_settings_bytes(bytes: &[u8]) -> Result<(), String> {
     std::fs::write(&path, pretty).map_err(|e| format!("write settings: {e}"))
 }
 
+/// Whether a core is currently initialized.
+///
+/// For background work that outlives the call that started it: the C# callback
+/// delegates are released at `mbrc_shutdown`, so a long-running job must not
+/// reach back into the host after one. This narrows that window rather than
+/// closing it - a shutdown between the check and the call is still possible -
+/// but it takes a stalled download that finishes minutes after MusicBee exited
+/// out of the picture entirely.
+pub fn is_initialized() -> bool {
+    lock().is_some()
+}
+
 /// The storage directory MusicBee handed the core at init, or `None` before
 /// then. The one place that answer lives, so nothing has to be told it twice.
 pub fn storage_path() -> Option<String> {
@@ -222,6 +234,7 @@ pub fn host_query(kind: HostQueryType, _params: &[u8]) -> Option<Vec<u8>> {
         HostQueryType::CacheStatus => cache_status_bytes(),
         HostQueryType::RecentBlocked => recent_blocked_bytes(),
         HostQueryType::ListeningAddresses => listening_info_bytes(),
+        HostQueryType::UpdateStatus => update_status_bytes(),
     }
 }
 
@@ -232,7 +245,30 @@ pub fn host_command(kind: HostCommandType, _params: &[u8]) -> MbrcResult {
         HostCommandType::RebuildMetadata => rebuild(RebuildScope::Metadata),
         HostCommandType::RebuildCovers => rebuild(RebuildScope::Covers),
         HostCommandType::ClearBlockedLog => clear_blocked(),
+        // Forced: the panel's button is an instruction, not a schedule, so it
+        // ignores both the enabled preference and the interval.
+        HostCommandType::CheckForUpdate => {
+            with_core(|core| crate::updates::service::start_check(core, true))
+        }
+        HostCommandType::DownloadUpdate => with_core(crate::updates::service::start_download),
+        HostCommandType::SkipUpdate => {
+            with_core(|core| crate::updates::service::skip_available(&core))
+        }
     }
+}
+
+/// Run `action` against the initialized core, or report `NotInitialized`. The
+/// lock is released before `action` runs: the update jobs it starts touch the
+/// core from their own threads.
+fn with_core(action: impl FnOnce(Arc<Core>) -> MbrcResult) -> MbrcResult {
+    let core = {
+        let guard = lock();
+        match guard.as_ref() {
+            Some(runtime) => runtime.core.clone(),
+            None => return MbrcResult::NotInitialized,
+        }
+    };
+    action(core)
 }
 
 /// Serialize the current cache status as MessagePack for the settings panel.
@@ -277,6 +313,17 @@ fn listening_info_bytes() -> Option<Vec<u8>> {
         .collect();
     let info = crate::ffi::dtos::ListeningInfo { port, addresses };
     rmp_serde::to_vec_named(&info).ok()
+}
+
+/// Serialize where the update flow stands as MessagePack for the settings panel.
+/// `None` if the core is not initialized; every other state is a real answer,
+/// including "nothing has been checked yet".
+fn update_status_bytes() -> Option<Vec<u8>> {
+    let core = {
+        let guard = lock();
+        guard.as_ref()?.core.clone()
+    };
+    crate::updates::service::status_bytes(&core)
 }
 
 /// Clear the in-memory blocked-connection log (the panel's "Clear" button).

--- a/packages/mbrc-core/src/updates/mod.rs
+++ b/packages/mbrc-core/src/updates/mod.rs
@@ -7,10 +7,12 @@
 //!
 //! Nothing here reaches the network on its own. It takes an
 //! [`HttpClient`](mbrc_release::HttpClient); [`http_client`] builds the
-//! production one (WinHTTP) from the user's settings, and the panel and the
-//! background schedule that call in arrive with the UI (#152).
+//! production one (WinHTTP) from the user's settings, and [`service`] is what
+//! decides when to hand it one - the panel's buttons and the one check the core
+//! runs shortly after networking starts.
 
 pub mod elevate;
+pub mod service;
 
 use mbrc_release::{
     check::{self, CheckOptions, CheckOutcome},

--- a/packages/mbrc-core/src/updates/service.rs
+++ b/packages/mbrc-core/src/updates/service.rs
@@ -1,0 +1,674 @@
+//! The update flow as the settings panel sees it: one status, one job at a time.
+//!
+//! Everything the panel can ask for - check, download, skip - is a
+//! fire-and-forget host command that starts a background thread, plus a status
+//! the panel polls (and a push event so it rarely has to). The panel therefore
+//! never blocks MusicBee's UI thread on a network request, and the core never
+//! has to be told which release to fetch: the only download it will perform is
+//! the one its own verified check produced.
+//!
+//! Two rules hold the state machine together:
+//!
+//! - **One job at a time.** A check and a download both talk to github.com and
+//!   both write the same status; running two would make the status a lie. A
+//!   second request while one runs is refused, not queued.
+//! - **The staged bundle wins.** If a version is already staged on disk, that is
+//!   what the user is offered, even if a fresh check finds the same version
+//!   "available" - the download already happened.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use mbrc_release::{check::CheckOutcome, AvailableUpdate, HttpClient, Result, UpdateState};
+
+use crate::ffi::types::{HostEventType, MbrcResult};
+use crate::state::Core;
+
+/// No check has run yet this session and nothing is staged.
+pub const STATE_UNKNOWN: &str = "unknown";
+/// A check is in flight.
+pub const STATE_CHECKING: &str = "checking";
+/// The published release is not newer than what is running.
+pub const STATE_UP_TO_DATE: &str = "up_to_date";
+/// A newer release is available and has not been downloaded.
+pub const STATE_AVAILABLE: &str = "available";
+/// The available release is being downloaded and staged.
+pub const STATE_DOWNLOADING: &str = "downloading";
+/// A verified bundle is staged and waiting for a restart.
+pub const STATE_STAGED: &str = "staged";
+/// A newer release exists but the user asked not to be offered this one.
+pub const STATE_SKIPPED: &str = "skipped";
+/// Automatic checking is off and the caller did not force a check.
+pub const STATE_DISABLED: &str = "disabled";
+/// The last check failed; `message` says how, and so does the log.
+pub const STATE_ERROR: &str = "error";
+/// The download of an available update failed. Distinct from [`STATE_ERROR`]
+/// because the update is still known and still worth retrying - and because
+/// "no update could be found" is the wrong thing to tell someone who just
+/// pressed Download.
+pub const STATE_DOWNLOAD_FAILED: &str = "download_failed";
+
+/// The status is a generated DTO (the C# side reads it by field name), so it
+/// lives with the rest of them; the states it can be in are decided here.
+pub use crate::ffi::dtos::UpdateStatus;
+
+impl Default for UpdateStatus {
+    fn default() -> Self {
+        Self {
+            state: STATE_UNKNOWN.to_owned(),
+            version: String::new(),
+            notes_url: String::new(),
+            min_musicbee_build: 0,
+            message: String::new(),
+            checked_at: String::new(),
+        }
+    }
+}
+
+impl UpdateStatus {
+    fn with_state(state: &str) -> Self {
+        Self {
+            state: state.to_owned(),
+            ..Self::default()
+        }
+    }
+}
+
+/// The current status, `None` until the first read seeds it from disk.
+static STATUS: Mutex<Option<UpdateStatus>> = Mutex::new(None);
+/// The verified update the last check produced, kept so a download has something
+/// to fetch that the host did not name.
+static AVAILABLE: Mutex<Option<Box<AvailableUpdate>>> = Mutex::new(None);
+/// Set while a check or a download is running.
+static BUSY: AtomicBool = AtomicBool::new(false);
+
+fn status_lock() -> MutexGuard<'static, Option<UpdateStatus>> {
+    STATUS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn available_lock() -> MutexGuard<'static, Option<Box<AvailableUpdate>>> {
+    AVAILABLE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Claims the right to run a job, releasing it on drop - including on a panic,
+/// so a job that dies does not wedge the panel's buttons for the session.
+struct Job;
+
+impl Job {
+    fn claim() -> Option<Self> {
+        if BUSY.swap(true, Ordering::AcqRel) {
+            None
+        } else {
+            Some(Self)
+        }
+    }
+}
+
+impl Drop for Job {
+    fn drop(&mut self) {
+        BUSY.store(false, Ordering::Release);
+    }
+}
+
+/// The status, seeded from disk on first read: a bundle staged in an earlier
+/// session is the answer even before anything has run this one.
+pub fn status(core: &Core) -> UpdateStatus {
+    let mut guard = status_lock();
+    guard
+        .get_or_insert_with(|| initial_status(&core.config.storage_path))
+        .clone()
+}
+
+/// Serialize the status as MessagePack for the settings panel.
+pub fn status_bytes(core: &Core) -> Option<Vec<u8>> {
+    rmp_serde::to_vec_named(&status(core)).ok()
+}
+
+/// Start a background check. `force` bypasses both the `update_check_enabled`
+/// preference and the interval; the panel's button forces, the startup check
+/// does not.
+pub fn start_check(core: Arc<Core>, force: bool) -> MbrcResult {
+    let Some(job) = Job::claim() else {
+        return MbrcResult::AlreadyRunning;
+    };
+    // What the panel is showing now, kept so an outcome that turns out to be no
+    // news can put it back.
+    let previous = status(&core);
+    // Only a forced check announces itself. The one the core runs a minute into
+    // the session has nobody waiting on it, and flashing "Checking for
+    // updates..." over an offer the user is reading would be pure noise.
+    if force {
+        publish(&core, UpdateStatus::with_state(STATE_CHECKING));
+    }
+    std::thread::spawn(move || {
+        let _job = job;
+        // The core can be shut down between the request and this thread being
+        // scheduled; there is then no host to report to.
+        if !crate::state::is_initialized() {
+            return;
+        }
+        let status = match client(&core) {
+            Ok(client) => run_check(&core, client.as_ref(), force, previous),
+            Err(e) => failure("could not start the update check", &e),
+        };
+        publish(&core, status);
+    });
+    MbrcResult::Ok
+}
+
+/// Start a background download of the update the last check produced. Refused
+/// when there is none: the host cannot name a release, only accept the one the
+/// core verified.
+pub fn start_download(core: Arc<Core>) -> MbrcResult {
+    let Some(update) = available_lock().clone() else {
+        tracing::warn!("a download was requested with no verified update to fetch");
+        return MbrcResult::InvalidArgument;
+    };
+    let Some(job) = Job::claim() else {
+        return MbrcResult::AlreadyRunning;
+    };
+    publish(&core, downloading(&update));
+    std::thread::spawn(move || {
+        let _job = job;
+        // The core can be shut down between the request and this thread being
+        // scheduled; there is then no host to report to.
+        if !crate::state::is_initialized() {
+            return;
+        }
+        let status = match client(&core) {
+            Ok(client) => run_download(&core, client.as_ref(), &update),
+            Err(e) => download_failure(&update, &e),
+        };
+        publish(&core, status);
+    });
+    MbrcResult::Ok
+}
+
+/// Record that the user does not want to be offered the available version again.
+///
+/// Only an actual offer can be skipped. `version` is populated for `up_to_date`
+/// too (it names the latest published release), so skipping "whatever the status
+/// names" would let a click that lands just after a status change permanently
+/// suppress the release the user is already running - and there is no UI to
+/// undo that.
+pub fn skip_available(core: &Core) -> MbrcResult {
+    let current = status(core);
+    let offered = matches!(
+        current.state.as_str(),
+        STATE_AVAILABLE | STATE_DOWNLOAD_FAILED
+    );
+    let version = current.version;
+    if !offered || version.is_empty() {
+        tracing::warn!(state = %current.state, "nothing on offer to skip");
+        return MbrcResult::InvalidArgument;
+    }
+    if let Err(e) = super::skip_version(&core.config, &version) {
+        tracing::warn!(error = %e, version = %version, "could not record the skipped version");
+        return MbrcResult::RuntimeError;
+    }
+    tracing::info!(version = %version, "the user skipped a release");
+    available_lock().take();
+    publish(
+        core,
+        UpdateStatus {
+            version,
+            ..UpdateStatus::with_state(STATE_SKIPPED)
+        },
+    );
+    MbrcResult::Ok
+}
+
+/// Runs the check and turns its result into the new status, stashing the
+/// verified update so a later download has something to fetch.
+fn run_check(
+    core: &Core,
+    client: &dyn HttpClient,
+    force: bool,
+    previous: UpdateStatus,
+) -> UpdateStatus {
+    // The plugin's version, not the core's: they are stamped from the same
+    // `Directory.Build.props`, but the release is the plugin's, and the host is
+    // the one that knows what it is running. Falling back keeps a host that
+    // cannot answer from blocking the check entirely.
+    let current = core.providers.plugin_version().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "the host could not report its version; using the core's");
+        super::CORE_VERSION.to_owned()
+    });
+
+    let outcome = super::check_for_update(client, &core.config, &current, force);
+    let checked_at = UpdateState::load(&core.config.storage_path)
+        .last_check
+        .unwrap_or_default();
+    let staged = staged_version(&core.config.storage_path);
+
+    match interpret(outcome, staged.as_deref(), &checked_at) {
+        Verdict::Fresh(status, available) => {
+            *available_lock() = available;
+            status
+        }
+        // Nothing learned, so nothing is disturbed - the stashed update in
+        // particular, which is what the Download button acts on.
+        Verdict::NoNews => no_news(previous, staged.as_deref(), &checked_at),
+    }
+}
+
+/// What a check result means for the two things a check can change: the status,
+/// and the verified update kept for a later download.
+enum Verdict {
+    /// A new answer. This status, and this (possibly absent) update to stash.
+    Fresh(UpdateStatus, Option<Box<AvailableUpdate>>),
+    /// No new information: a `304`, or a check that was not due. Whatever was
+    /// already known still holds, offers included.
+    NoNews,
+}
+
+/// The status when a check told us nothing new.
+///
+/// An offer the user has not acted on outlives it - dropping back to "up to
+/// date" would take the Download button away from someone who was about to press
+/// it, and the second check of a session is a `304` almost every time. Anything
+/// else falls back to what the disk says.
+fn no_news(previous: UpdateStatus, staged: Option<&str>, checked_at: &str) -> UpdateStatus {
+    let actionable = matches!(
+        previous.state.as_str(),
+        STATE_AVAILABLE | STATE_DOWNLOAD_FAILED | STATE_STAGED | STATE_SKIPPED
+    );
+    let mut status = if actionable { previous } else { quiet(staged) };
+    status.checked_at = checked_at.to_owned();
+    status
+}
+
+/// Maps a check result onto the status and, when there is one to keep, the
+/// verified update behind it.
+///
+/// Split out from the network call so the mapping - which is where the states
+/// the panel switches on are decided - is testable without one.
+fn interpret(outcome: Result<CheckOutcome>, staged: Option<&str>, checked_at: &str) -> Verdict {
+    let stamp = |mut status: UpdateStatus| {
+        status.checked_at = checked_at.to_owned();
+        status
+    };
+
+    match outcome {
+        Ok(CheckOutcome::Available(update)) => {
+            // Already downloaded in an earlier session: offer the restart, not
+            // the download.
+            let state = if staged == Some(update.manifest.version.as_str()) {
+                STATE_STAGED
+            } else {
+                STATE_AVAILABLE
+            };
+            let status = stamp(UpdateStatus {
+                version: update.manifest.version.clone(),
+                notes_url: update.manifest.notes_url.clone(),
+                min_musicbee_build: update.manifest.min_musicbee_build,
+                ..UpdateStatus::with_state(state)
+            });
+            Verdict::Fresh(status, Some(update))
+        }
+        Ok(CheckOutcome::UpToDate { latest }) => Verdict::Fresh(
+            stamp(UpdateStatus {
+                version: latest,
+                ..UpdateStatus::with_state(STATE_UP_TO_DATE)
+            }),
+            None,
+        ),
+        Ok(CheckOutcome::Skipped { version }) => Verdict::Fresh(
+            stamp(UpdateStatus {
+                version,
+                ..UpdateStatus::with_state(STATE_SKIPPED)
+            }),
+            None,
+        ),
+        // A 304 says the release document has not changed since the ETag we
+        // cached, and "not due" says we did not ask. Neither is news, and
+        // neither may be allowed to retract an offer already on screen.
+        Ok(CheckOutcome::NotModified) | Ok(CheckOutcome::NotDue) => Verdict::NoNews,
+        Ok(CheckOutcome::Disabled) => {
+            Verdict::Fresh(UpdateStatus::with_state(STATE_DISABLED), None)
+        }
+        Err(e) => {
+            let detail = e.to_string();
+            tracing::warn!(error = %detail, "the update check failed");
+            // A staged bundle outlives a failed check: the restart is still the
+            // thing to offer, with the failure as a footnote rather than as the
+            // whole answer.
+            let mut status = match staged {
+                Some(_) => quiet(staged),
+                None => UpdateStatus::with_state(STATE_ERROR),
+            };
+            status.message = detail;
+            Verdict::Fresh(stamp(status), None)
+        }
+    }
+}
+
+/// The status a check with nothing to report falls back to: the staged bundle if
+/// there is one, otherwise up to date.
+fn quiet(staged: Option<&str>) -> UpdateStatus {
+    match staged {
+        Some(version) => UpdateStatus {
+            version: version.to_owned(),
+            ..UpdateStatus::with_state(STATE_STAGED)
+        },
+        None => UpdateStatus::with_state(STATE_UP_TO_DATE),
+    }
+}
+
+/// Downloads and stages the update, leaving the status on the restart the helper
+/// is now waiting for.
+fn run_download(core: &Core, client: &dyn HttpClient, update: &AvailableUpdate) -> UpdateStatus {
+    match super::stage_update(client, &core.config, update) {
+        Ok(staged) => UpdateStatus {
+            version: staged.version,
+            notes_url: update.manifest.notes_url.clone(),
+            min_musicbee_build: update.manifest.min_musicbee_build,
+            ..UpdateStatus::with_state(STATE_STAGED)
+        },
+        Err(e) => download_failure(update, &e.to_string()),
+    }
+}
+
+/// A failed download, which keeps naming the update it was for: the verified
+/// update is still stashed, so retrying is one press away.
+fn download_failure(update: &AvailableUpdate, detail: &str) -> UpdateStatus {
+    tracing::warn!(error = detail, version = %update.manifest.version, "the download failed");
+    UpdateStatus {
+        version: update.manifest.version.clone(),
+        notes_url: update.manifest.notes_url.clone(),
+        min_musicbee_build: update.manifest.min_musicbee_build,
+        message: detail.to_owned(),
+        ..UpdateStatus::with_state(STATE_DOWNLOAD_FAILED)
+    }
+}
+
+fn downloading(update: &AvailableUpdate) -> UpdateStatus {
+    UpdateStatus {
+        version: update.manifest.version.clone(),
+        notes_url: update.manifest.notes_url.clone(),
+        min_musicbee_build: update.manifest.min_musicbee_build,
+        ..UpdateStatus::with_state(STATE_DOWNLOADING)
+    }
+}
+
+/// An error status, logged as it is built: the panel gets one line, the log gets
+/// the whole thing.
+fn failure(context: &str, detail: &str) -> UpdateStatus {
+    tracing::warn!(error = detail, "{context}");
+    UpdateStatus {
+        message: detail.to_owned(),
+        ..UpdateStatus::with_state(STATE_ERROR)
+    }
+}
+
+/// The status a session starts from: whatever is staged on disk, or nothing.
+fn initial_status(storage: &str) -> UpdateStatus {
+    match staged_version(storage) {
+        Some(version) => UpdateStatus {
+            version,
+            ..UpdateStatus::with_state(STATE_STAGED)
+        },
+        None => UpdateStatus::default(),
+    }
+}
+
+/// The version of the bundle staged for the next restart, if there is one.
+fn staged_version(storage: &str) -> Option<String> {
+    match mbrc_release::read_pending(storage) {
+        Ok(pending) => pending.map(|p| p.version),
+        Err(e) => {
+            tracing::warn!(error = %e, "the staged-update marker is unreadable");
+            None
+        }
+    }
+}
+
+/// Store the new status and tell the host, so an open panel refreshes without
+/// waiting for its poll.
+///
+/// The event is skipped once the core has been shut down: these jobs run on
+/// detached threads that can outlive MusicBee's exit by as long as an HTTP
+/// request takes, and `on_event` is a C# delegate that does not survive it.
+fn publish(core: &Core, status: UpdateStatus) {
+    tracing::debug!(state = %status.state, version = %status.version, "update status");
+    let alive = crate::state::is_initialized();
+    *status_lock() = Some(status);
+    if alive {
+        core.providers
+            .emit_event(HostEventType::UpdateStatusChanged, &[]);
+    }
+}
+
+/// The production HTTP client, boxed so the callers above are written once
+/// against the trait.
+#[cfg(windows)]
+fn client(core: &Core) -> std::result::Result<Box<dyn HttpClient>, String> {
+    super::http_client(&core.config)
+        .map(|c| Box::new(c) as Box<dyn HttpClient>)
+        .map_err(|e| e.to_string())
+}
+
+/// There is no MusicBee here to update. Kept so the module compiles and its
+/// tests run on the Linux CI runner.
+#[cfg(not(windows))]
+fn client(_core: &Core) -> std::result::Result<Box<dyn HttpClient>, String> {
+    Err("updates are only supported on Windows".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mbrc_release::{
+        manifest::{Artifact, Artifacts},
+        Channel, Manifest, UpdateError,
+    };
+
+    fn manifest(version: &str) -> Manifest {
+        Manifest {
+            schema: 1,
+            channel: Channel::Stable,
+            version: version.to_owned(),
+            released_at: "2026-08-16T00:00:00Z".to_owned(),
+            abi_version: 1,
+            min_musicbee_build: 6500,
+            notes_url: "https://example.invalid/notes".to_owned(),
+            artifacts: Artifacts {
+                zip: Artifact {
+                    name: "mbrc.zip".to_owned(),
+                    size: 1,
+                    sha512: "0".repeat(128),
+                },
+                installer: Artifact {
+                    name: "mbrc.exe".to_owned(),
+                    size: 1,
+                    sha512: "0".repeat(128),
+                },
+            },
+            files: Vec::new(),
+        }
+    }
+
+    fn available(version: &str) -> Result<CheckOutcome> {
+        Ok(CheckOutcome::Available(Box::new(AvailableUpdate {
+            manifest: manifest(version),
+            manifest_bytes: Vec::new(),
+            signature: String::new(),
+            zip_url: "https://example.invalid/mbrc.zip".to_owned(),
+            key_name: "test",
+        })))
+    }
+
+    /// The `Fresh` half of a verdict, for the cases that must produce one.
+    fn fresh(verdict: Verdict) -> (UpdateStatus, Option<Box<AvailableUpdate>>) {
+        match verdict {
+            Verdict::Fresh(status, update) => (status, update),
+            Verdict::NoNews => panic!("expected a fresh answer, got NoNews"),
+        }
+    }
+
+    #[test]
+    fn an_available_update_carries_what_the_panel_renders() {
+        let (status, update) = fresh(interpret(available("1.6.0"), None, "2026-08-16T10:00:00Z"));
+        assert_eq!(status.state, STATE_AVAILABLE);
+        assert_eq!(status.version, "1.6.0");
+        assert_eq!(status.notes_url, "https://example.invalid/notes");
+        assert_eq!(status.min_musicbee_build, 6500);
+        assert_eq!(status.checked_at, "2026-08-16T10:00:00Z");
+        assert!(status.message.is_empty());
+        // Kept, because a download has nothing else to go on.
+        assert!(update.is_some());
+    }
+
+    #[test]
+    fn an_already_staged_version_is_offered_as_a_restart_not_a_download() {
+        let (status, _) = fresh(interpret(available("1.6.0"), Some("1.6.0"), ""));
+        assert_eq!(status.state, STATE_STAGED);
+        assert_eq!(status.version, "1.6.0");
+
+        // A *different* staged version does not mask a newer release.
+        let (status, _) = fresh(interpret(available("1.7.0"), Some("1.6.0"), ""));
+        assert_eq!(status.state, STATE_AVAILABLE);
+        assert_eq!(status.version, "1.7.0");
+    }
+
+    #[test]
+    fn up_to_date_is_a_fresh_answer_and_keeps_nothing() {
+        let (status, update) = fresh(interpret(
+            Ok(CheckOutcome::UpToDate {
+                latest: "1.5.0".to_owned(),
+            }),
+            None,
+            "",
+        ));
+        assert_eq!(status.state, STATE_UP_TO_DATE);
+        assert!(update.is_none());
+    }
+
+    #[test]
+    fn no_news_outcomes_do_not_answer_at_all() {
+        // A 304 and a not-due check learned nothing, so they must not be turned
+        // into an answer: doing so is what would let the *second* press of Check
+        // now retract the offer the first one found.
+        for outcome in [Ok(CheckOutcome::NotModified), Ok(CheckOutcome::NotDue)] {
+            assert!(matches!(interpret(outcome, None, ""), Verdict::NoNews));
+        }
+    }
+
+    #[test]
+    fn an_offer_outlives_a_check_with_no_news() {
+        let offered = UpdateStatus {
+            version: "1.6.0".to_owned(),
+            notes_url: "https://example.invalid/notes".to_owned(),
+            ..UpdateStatus::with_state(STATE_AVAILABLE)
+        };
+        let kept = no_news(offered, None, "2026-08-16T11:00:00Z");
+        assert_eq!(kept.state, STATE_AVAILABLE, "the offer must survive a 304");
+        assert_eq!(kept.version, "1.6.0");
+        assert_eq!(kept.checked_at, "2026-08-16T11:00:00Z");
+
+        // With nothing to preserve, it falls back to what the disk says.
+        let fallback = no_news(UpdateStatus::default(), None, "");
+        assert_eq!(fallback.state, STATE_UP_TO_DATE);
+        let staged = no_news(UpdateStatus::default(), Some("1.6.0"), "");
+        assert_eq!(staged.state, STATE_STAGED);
+        assert_eq!(staged.version, "1.6.0");
+    }
+
+    #[test]
+    fn a_staged_bundle_survives_a_failed_check() {
+        // Losing the restart button because a later check could not reach github
+        // would strand a download the user has already approved.
+        let (status, _) = fresh(interpret(
+            Err(UpdateError::Network("host unreachable".to_owned())),
+            Some("1.6.0"),
+            "",
+        ));
+        assert_eq!(status.state, STATE_STAGED);
+        assert_eq!(status.version, "1.6.0");
+        assert!(
+            status.message.contains("host unreachable"),
+            "the failure is still reported: {}",
+            status.message
+        );
+    }
+
+    #[test]
+    fn a_skipped_version_is_its_own_state() {
+        let (status, update) = fresh(interpret(
+            Ok(CheckOutcome::Skipped {
+                version: "1.6.0".to_owned(),
+            }),
+            None,
+            "",
+        ));
+        assert_eq!(status.state, STATE_SKIPPED);
+        assert_eq!(status.version, "1.6.0");
+        assert!(update.is_none());
+    }
+
+    #[test]
+    fn a_failed_check_reports_the_detail_and_drops_any_stale_update() {
+        let (status, update) = fresh(interpret(
+            Err(UpdateError::Network("host unreachable".to_owned())),
+            None,
+            "",
+        ));
+        assert_eq!(status.state, STATE_ERROR);
+        assert!(
+            status.message.contains("host unreachable"),
+            "{}",
+            status.message
+        );
+        assert!(update.is_none());
+    }
+
+    #[test]
+    fn a_disabled_check_is_not_stamped_as_a_check() {
+        let (status, _) = fresh(interpret(
+            Ok(CheckOutcome::Disabled),
+            None,
+            "2026-08-16T10:00:00Z",
+        ));
+        assert_eq!(status.state, STATE_DISABLED);
+        // Nothing reached the network, so nothing was checked.
+        assert!(status.checked_at.is_empty());
+    }
+
+    #[test]
+    fn an_empty_storage_directory_starts_from_nothing_staged() {
+        let dir = std::env::temp_dir().join("mbrc-update-service-initial");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(
+            initial_status(&dir.to_string_lossy()),
+            UpdateStatus::default()
+        );
+    }
+
+    #[test]
+    fn a_failed_download_still_names_its_update() {
+        // Its own state, because "no update could be found" is the wrong thing to
+        // tell someone who just pressed Download - and because the update is
+        // still there to retry.
+        let update = match available("1.6.0") {
+            Ok(CheckOutcome::Available(update)) => update,
+            _ => unreachable!(),
+        };
+        let status = download_failure(&update, "connection reset");
+        assert_eq!(status.state, STATE_DOWNLOAD_FAILED);
+        assert_eq!(status.version, "1.6.0");
+        assert_eq!(status.message, "connection reset");
+    }
+
+    #[test]
+    fn the_job_guard_releases_on_drop() {
+        let first = Job::claim().expect("nothing else is running");
+        assert!(Job::claim().is_none(), "two jobs must not run at once");
+        drop(first);
+        assert!(Job::claim().is_some(), "the guard did not release");
+    }
+}

--- a/packages/mbrc-release/src/check.rs
+++ b/packages/mbrc-release/src/check.rs
@@ -123,7 +123,8 @@ pub enum CheckOutcome {
 /// together, so its ABI is internally consistent by construction, and refusing an
 /// update because it bumped the ABI would block exactly the updates that need to
 /// ship. The MusicBee build gate belongs where the MusicBee version is known,
-/// which is the panel (#152), not here.
+/// which is the panel, not here: it reads the build from `MusicBee.exe`'s file
+/// version and greys out the download when the release needs a newer one.
 pub fn check(
     client: &dyn HttpClient,
     options: &CheckOptions<'_>,

--- a/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeDtos.Generated.cs
@@ -283,6 +283,16 @@ namespace MusicBeePlugin.Ffi
         public string reason { get; set; }
     }
 
+    public class UpdateStatus
+    {
+        public string state { get; set; }
+        public string version { get; set; }
+        public string notes_url { get; set; }
+        public uint min_musicbee_build { get; set; }
+        public string message { get; set; }
+        public string checked_at { get; set; }
+    }
+
     public class ListeningInfo
     {
         public ushort port { get; set; }

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -118,6 +118,7 @@ namespace MusicBeePlugin.Ffi.Generated
         CacheStatus = 1,
         RecentBlocked = 2,
         ListeningAddresses = 3,
+        UpdateStatus = 4,
     }
 
     public enum HostCommandType
@@ -125,11 +126,15 @@ namespace MusicBeePlugin.Ffi.Generated
         RebuildMetadata = 1,
         RebuildCovers = 2,
         ClearBlockedLog = 3,
+        CheckForUpdate = 4,
+        DownloadUpdate = 5,
+        SkipUpdate = 6,
     }
 
     public enum HostEventType
     {
         CacheStatusChanged = 1,
+        UpdateStatusChanged = 2,
     }
 
 }

--- a/packages/plugin/Ffi/NativeBridge.cs
+++ b/packages/plugin/Ffi/NativeBridge.cs
@@ -419,6 +419,32 @@ namespace MusicBeePlugin.Ffi
         public bool ClearBlockedConnections() => Command(HostCommandType.ClearBlockedLog);
 
         /// <summary>
+        ///     Where the update flow stands, for the settings panel's Updates
+        ///     group. Always answers while the core is up, including before any
+        ///     check has run. Null if the core is not initialized.
+        /// </summary>
+        public UpdateStatus ReadUpdateStatus() => Query<UpdateStatus>(HostQueryType.UpdateStatus);
+
+        /// <summary>
+        ///     Start a background check for a newer release. Forced: the panel's
+        ///     button is a direct instruction, so it runs whatever the automatic-
+        ///     check preference says. False if a check or download is already
+        ///     running (or the core is down); the result arrives as an
+        ///     <see cref="HostEventType.UpdateStatusChanged" /> event.
+        /// </summary>
+        public bool CheckForUpdate() => Command(HostCommandType.CheckForUpdate);
+
+        /// <summary>
+        ///     Start a background download of the update the last check found and
+        ///     stage it for the next restart. False when no check has produced one
+        ///     - the host cannot name a release, only accept the verified one.
+        /// </summary>
+        public bool DownloadUpdate() => Command(HostCommandType.DownloadUpdate);
+
+        /// <summary>Record that the user does not want this version offered again.</summary>
+        public bool SkipUpdate() => Command(HostCommandType.SkipUpdate);
+
+        /// <summary>
         ///     Apply the log level to the core's filter live (no restart needed).
         ///     <paramref name="logLevel"/> is the settings value (<c>info</c> /
         ///     <c>debug</c> / <c>trace</c>), mapped to a tracing filter directive.

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -20,6 +20,14 @@ namespace MusicBeePlugin.Host
     public sealed class PluginHost : IDisposable
     {
         private readonly NativeBridge _bridge;
+
+        /// <summary>
+        ///     MusicBee's API struct. Kept (a copy of the delegate table) only for
+        ///     the few host-level calls that are not part of a provider - closing
+        ///     MusicBee to finish an update is the one that matters.
+        /// </summary>
+        private readonly Plugin.MusicBeeApiInterface _api;
+
         private readonly UserSettingsService _userSettings;
         private readonly ISystemOperations _system;
         private readonly IPluginLogger _logger;
@@ -32,6 +40,7 @@ namespace MusicBeePlugin.Host
             // folder the core writes mbrc-core.log to (<storage>/mb_remote).
             var storageDir = Path.Combine(storagePath, "mb_remote");
             _logger = new FfiLogger("mbrc.host", storageDir);
+            _api = api;
 
             // MusicBee-API-bound leaves: providers wrap the raw interface struct.
             _system = new SystemOperations(api);
@@ -111,6 +120,31 @@ namespace MusicBeePlugin.Host
 
         /// <summary>Clear the core's in-memory blocked-connection log.</summary>
         public bool ClearBlockedConnections() => _bridge.ClearBlockedConnections();
+
+        /// <summary>Where the update flow stands, for the panel's Updates group.</summary>
+        public Ffi.UpdateStatus ReadUpdateStatus() => _bridge.ReadUpdateStatus();
+
+        /// <summary>Start a background check for a newer release (always forced).</summary>
+        public bool CheckForUpdate() => _bridge.CheckForUpdate();
+
+        /// <summary>Download and stage the update the last check found.</summary>
+        public bool DownloadUpdate() => _bridge.DownloadUpdate();
+
+        /// <summary>Record that the user does not want this version offered again.</summary>
+        public bool SkipUpdate() => _bridge.SkipUpdate();
+
+        /// <summary>
+        ///     Hand the staged update to the elevated helper. On
+        ///     <see cref="Ffi.Generated.UpdateLaunch.Launched" /> the helper is up and
+        ///     waiting for MusicBee to exit, so the caller must close MusicBee next.
+        /// </summary>
+        public Ffi.Generated.UpdateLaunch ApplyStagedUpdate() => _bridge.ApplyStagedUpdate();
+
+        /// <summary>
+        ///     MusicBee's own window, so the panel can ask it to close once an
+        ///     update has been handed to the helper.
+        /// </summary>
+        public IntPtr MusicBeeWindow => _api.MB_GetWindowHandle();
 
         /// <summary>
         ///     Core -> host push events (raised on a background thread). The

--- a/packages/plugin/Settings/CoreSettings.cs
+++ b/packages/plugin/Settings/CoreSettings.cs
@@ -33,5 +33,12 @@ namespace MusicBeePlugin.Settings
 
         /// <summary>Core log verbosity: <c>info</c> / <c>debug</c> / <c>trace</c>.</summary>
         public string log_level { get; set; } = "info";
+
+        /// <summary>
+        ///     Whether the core checks for a newer release on its own. Off by
+        ///     default: an automatic check is an unprompted request to github.com.
+        ///     The panel's "Check now" button works regardless of this.
+        /// </summary>
+        public bool update_check_enabled { get; set; }
     }
 }

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows.Forms;
@@ -47,6 +48,29 @@ namespace MusicBeePlugin.Settings
         // Plugin help / documentation, opened from the footer link.
         private const string HelpUrl = "https://mbrc.kelsos.net/help/plugin/";
 
+        // The dialog's fixed width, and the height it wants when the screen has
+        // room. Six groups plus the footer do not fit a 720p screen (or a 1080p
+        // one at 150% scaling, which is the same thing in logical pixels), so the
+        // height is what actually gets clamped - see PreferredDialogHeight.
+        private const int DialogWidth = 560;
+        private const int DialogHeight = 780;
+
+        // Usable width of a group's value column: the dialog's client width less
+        // the 140px label column and the layout's padding. Wrapping labels are
+        // capped to it so a long sentence stays inside the fixed-width dialog.
+        // Kept clear of the value column's full width so that a vertical
+        // scrollbar (about 17px) appearing on a short screen cannot push the
+        // longest line into needing a horizontal one too.
+        private const int StatusWidth = 355;
+
+        // Closing MusicBee after an update is handed to the helper: the same
+        // message its own title bar sends.
+        private const uint WM_CLOSE = 0x0010;
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
         private readonly PluginHost _host;
         private readonly string _version;
 
@@ -67,6 +91,19 @@ namespace MusicBeePlugin.Settings
         private System.Windows.Forms.Timer _blockedTimer;
         private Button _rebuildMeta;
         private Button _rebuildCovers;
+        private Label _updateStatus;
+        private Button _updateAction;
+        private Button _updateSkip;
+        private LinkLabel _releaseNotes;
+        private CheckBox _autoCheck;
+        private string _updateState = UpdateStates.Unknown;
+        private string _notesUrl = string.Empty;
+
+        /// <summary>
+        ///     The offered release needs a newer MusicBee than this one, so the
+        ///     action button re-checks instead of downloading.
+        /// </summary>
+        private bool _updateBlocked;
 
         public SettingsDialog(PluginHost host, string version)
         {
@@ -80,17 +117,19 @@ namespace MusicBeePlugin.Settings
             MinimizeBox = false;
             ShowInTaskbar = false;
             AutoScaleMode = AutoScaleMode.Font;
-            ClientSize = new Size(560, 660);
+            ClientSize = new Size(DialogWidth, PreferredDialogHeight());
 
             BuildLayout();
             LoadFromCore();
             LoadListeningAddresses();
             LoadCacheStatus();
             LoadBlockedCount();
+            LoadUpdateStatus();
             RunConnectionTest();
 
-            // The core pushes a CacheStatusChanged event when a rebuild starts or
-            // finishes; refresh the line live while this dialog is open.
+            // The core pushes CacheStatusChanged when a rebuild starts or
+            // finishes, and UpdateStatusChanged when a check or download does;
+            // refresh those lines live while this dialog is open.
             _host.CoreEvent += OnCoreEvent;
 
             // The blocked-connections log has no push event (it is polled), so keep
@@ -109,21 +148,60 @@ namespace MusicBeePlugin.Settings
             base.OnFormClosed(e);
         }
 
+        /// <summary>
+        ///     The dialog's client height: what the layout wants, or as much of it
+        ///     as the screen can actually show. A fixed-size window taller than the
+        ///     work area puts its bottom-docked footer - Save included - off-screen
+        ///     with no way to scroll to it, which is worse than a shorter window
+        ///     that scrolls. Measured against the work area, so the taskbar counts.
+        /// </summary>
+        private static int PreferredDialogHeight()
+        {
+            try
+            {
+                // Screen coordinates are physical pixels and ClientSize is logical,
+                // but the form has not been created yet, so there is no scale factor
+                // to ask for. The margin below absorbs the difference; getting this
+                // slightly conservative is the harmless direction.
+                var available = Screen.PrimaryScreen.WorkingArea.Height - ChromeAllowance;
+                return available < DialogHeight ? Math.Max(available, MinimumDialogHeight) : DialogHeight;
+            }
+            catch (Exception)
+            {
+                // No screen to ask (a headless or unusual session): take the small
+                // size, which fits everywhere.
+                return MinimumDialogHeight;
+            }
+        }
+
+        // Room left for the title bar and borders, plus a little slack so the
+        // window does not sit flush against the taskbar.
+        private const int ChromeAllowance = 60;
+
+        // Below this the dialog stops shrinking and just scrolls further.
+        private const int MinimumDialogHeight = 420;
+
         private void BuildLayout()
         {
+            // Docked to the top and auto-sizing, so the table grows to whatever
+            // height its groups need instead of squeezing them into the window.
+            // That overflow is what the scroller below can then scroll: a
+            // Dock=Fill table lays its rows out inside its own bounds and clips
+            // them, leaving AutoScroll nothing to act on.
             var root = new TableLayoutPanel
             {
-                Dock = DockStyle.Fill,
+                Dock = DockStyle.Top,
                 ColumnCount = 1,
                 Padding = new Padding(12),
-                AutoSize = false,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
             };
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // connection
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // access
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // library
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // advanced
             root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // cache
-            root.RowStyles.Add(new RowStyle(SizeType.Percent, 100)); // spacer
+            root.RowStyles.Add(new RowStyle(SizeType.AutoSize)); // updates
 
             // No title label: the window title bar already reads "MusicBee Remote";
             // the version sits bottom-left in the button row instead.
@@ -132,18 +210,36 @@ namespace MusicBeePlugin.Settings
             root.Controls.Add(BuildLibraryGroup());
             root.Controls.Add(BuildAdvancedGroup());
             root.Controls.Add(BuildCacheGroup());
-            root.Controls.Add(new Panel { Dock = DockStyle.Fill }); // spacer
+            root.Controls.Add(BuildUpdatesGroup());
+            // No trailing spacer row: a Percent-100 row would absorb every
+            // overflow and the scroller below would never see one.
+
+            // The scrolling viewport. The groups live in here; the footer does
+            // not, which is the point - on a screen too short for the whole
+            // dialog the settings scroll and Save/Close stay put.
+            // The scroll extent is measured from where the child controls end,
+            // which counts neither the table's bottom padding nor the last
+            // group's margin - so the bottom of the last group stays just out of
+            // reach. AutoScrollMargin is the knob for that: it pads the
+            // scrollable area itself, and it has to clear both.
+            var scroller = new Panel
+            {
+                Dock = DockStyle.Fill,
+                AutoScroll = true,
+                AutoScrollMargin = new Size(0, 24),
+            };
+            scroller.Controls.Add(root);
 
             // The button row is docked to the bottom of the form so it (and the
             // version/Help footer inside it) always stays on-screen even if the
-            // grouped settings above overflow the fixed dialog height. Add the
+            // grouped settings above overflow the dialog height. Add the
             // bottom-docked row first, then the fill panel, so the fill claims the
             // remaining space above it.
             var footer = BuildButtonRow();
             footer.Dock = DockStyle.Bottom;
             footer.Padding = new Padding(12, 6, 12, 10);
             Controls.Add(footer);
-            Controls.Add(root);
+            Controls.Add(scroller);
         }
 
         private Control BuildConnectionGroup()
@@ -334,6 +430,79 @@ namespace MusicBeePlugin.Settings
             return WrapGroup("Cache", layout);
         }
 
+        private Control BuildUpdatesGroup()
+        {
+            _updateStatus = new Label
+            {
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+                Padding = new Padding(0, 6, 0, 0),
+                ForeColor = SystemColors.GrayText,
+                // Wrap instead of running off the fixed-width dialog: this line
+                // carries whole sentences (a failure reason, a build
+                // requirement), not the one-word status the other groups show.
+                MaximumSize = new Size(StatusWidth, 0),
+            };
+
+            // One button whose meaning follows the state (check / download /
+            // install), because at any moment there is exactly one sensible next
+            // step and three permanently-greyed buttons explain nothing.
+            _updateAction = new Button
+            {
+                Text = "Check now",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0, 0, 8, 0),
+            };
+            _updateAction.Click += (s, e) => RunUpdateAction();
+
+            _updateSkip = new Button
+            {
+                Text = "Skip this version",
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Margin = new Padding(0, 0, 8, 0),
+                Visible = false,
+            };
+            _updateSkip.Click += (s, e) => SkipUpdate();
+
+            _releaseNotes = new LinkLabel
+            {
+                Text = "Release notes",
+                AutoSize = true,
+                Padding = new Padding(0, 5, 0, 0),
+                Margin = new Padding(0),
+                Visible = false,
+            };
+            _releaseNotes.LinkClicked += (s, e) => OpenReleaseNotes();
+
+            var buttons = new FlowLayoutPanel
+            {
+                FlowDirection = FlowDirection.LeftToRight,
+                WrapContents = false,
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                Anchor = AnchorStyles.Left,
+                Margin = new Padding(0),
+            };
+            buttons.Controls.Add(_updateAction);
+            buttons.Controls.Add(_updateSkip);
+            buttons.Controls.Add(_releaseNotes);
+
+            _autoCheck = new CheckBox
+            {
+                Text = "Check for updates automatically",
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+            };
+
+            var layout = GroupLayout();
+            AddRow(layout, "Status", _updateStatus);
+            AddRow(layout, string.Empty, buttons);
+            AddRow(layout, string.Empty, _autoCheck);
+            return WrapGroup("Updates", layout);
+        }
+
         private Control BuildButtonRow()
         {
             // Bottom-left: the version (the title bar already names the plugin), a
@@ -494,6 +663,7 @@ namespace MusicBeePlugin.Settings
             _searchSource.SelectedIndex = SourceToIndex(s.search_source);
             _logLevel.SelectedIndex = LogLevelToIndex(s.log_level);
             _firewall.Checked = s.update_firewall;
+            _autoCheck.Checked = s.update_check_enabled;
             UpdateFilterEnabled();
             SetStatus(string.Empty, true);
         }
@@ -577,6 +747,262 @@ namespace MusicBeePlugin.Settings
                 dialog.ShowDialog(this);
             }
             LoadBlockedCount();
+        }
+
+        /// <summary>
+        ///     Render the core's update status: the line, what the one action
+        ///     button currently means, and whether skipping or reading the notes
+        ///     is on offer.
+        /// </summary>
+        private void LoadUpdateStatus()
+        {
+            var status = _host.ReadUpdateStatus();
+            if (status == null)
+            {
+                _updateState = UpdateStates.Unknown;
+                _notesUrl = string.Empty;
+                _updateStatus.Text = "Unavailable (core not running).";
+                _updateAction.Text = "Check now";
+                _updateAction.Enabled = false;
+                _updateSkip.Visible = false;
+                _releaseNotes.Visible = false;
+                return;
+            }
+
+            _updateState = status.state ?? UpdateStates.Unknown;
+            _notesUrl = status.notes_url ?? string.Empty;
+
+            // The core cannot see MusicBee's version, so the manifest's floor is
+            // enforced here, where the running build is a process away.
+            // An update the panel could download: the states where the button
+            // fetches rather than checks or installs. The core cannot see
+            // MusicBee's version, so the manifest's floor is enforced here, where
+            // the running build is a process away.
+            var offered = _updateState == UpdateStates.Available
+                          || _updateState == UpdateStates.DownloadFailed;
+            var build = MusicBeeBuild();
+            _updateBlocked = offered
+                             && build > 0
+                             && status.min_musicbee_build > 0
+                             && build < status.min_musicbee_build;
+
+            _updateStatus.Text = DescribeUpdate(status, _updateBlocked, build);
+            // A release that needs a newer MusicBee leaves the button offering a
+            // re-check rather than greying it out: greyed, the only control in the
+            // group would be dead for the rest of the session, with nothing to
+            // press after upgrading MusicBee or once a compatible release lands.
+            _updateAction.Text = _updateBlocked ? "Check now" : ActionLabel(_updateState);
+            _updateAction.Enabled = _updateState != UpdateStates.Checking
+                                    && _updateState != UpdateStates.Downloading;
+            _updateSkip.Visible = offered;
+            _releaseNotes.Visible = _notesUrl.Length > 0
+                                    && (offered || _updateState == UpdateStates.Staged);
+        }
+
+        private static string ActionLabel(string state)
+        {
+            switch (state)
+            {
+                case UpdateStates.Available: return "Download";
+                case UpdateStates.DownloadFailed: return "Retry download";
+                case UpdateStates.Staged: return "Install and restart";
+                case UpdateStates.Checking: return "Checking...";
+                case UpdateStates.Downloading: return "Downloading...";
+                default: return "Check now";
+            }
+        }
+
+        private static string DescribeUpdate(Ffi.UpdateStatus status, bool tooOld, int build)
+        {
+            var version = status.version ?? string.Empty;
+            if (tooOld)
+                return $"Version {version} needs MusicBee build {status.min_musicbee_build} or newer "
+                       + $"(this is build {build}).";
+
+            switch (status.state)
+            {
+                case UpdateStates.Checking:
+                    return "Checking for updates...";
+                case UpdateStates.Available:
+                    return $"Version {version} is available." + LastChecked(status);
+                case UpdateStates.Downloading:
+                    return $"Downloading version {version}...";
+                case UpdateStates.DownloadFailed:
+                    return $"Version {version} could not be downloaded - see the log for details.";
+                case UpdateStates.Staged:
+                    return $"Version {version} is ready to install.";
+                case UpdateStates.Skipped:
+                    return $"Version {version} was skipped." + LastChecked(status);
+                case UpdateStates.UpToDate:
+                    return (version.Length > 0
+                               ? $"Up to date (latest release is {version})."
+                               : "Up to date.")
+                           + LastChecked(status);
+                case UpdateStates.Disabled:
+                    return "Automatic checks are off. Use Check now.";
+                case UpdateStates.Error:
+                    // Whatever went wrong - an unreachable host, a release with no
+                    // manifest, a signature that did not verify - the user's answer
+                    // is the same and the diagnostic is already in mbrc-core.log,
+                    // written by the core as the failure happened.
+                    return "No update could be found." + LastChecked(status);
+                default:
+                    return "Not checked yet.";
+            }
+        }
+
+        /// <summary>
+        ///     " Last checked &lt;local time&gt;." for a status that carries one.
+        ///     The core stores UTC; the user reads local.
+        /// </summary>
+        private static string LastChecked(Ffi.UpdateStatus status)
+        {
+            if (string.IsNullOrEmpty(status.checked_at)) return string.Empty;
+            DateTime when;
+            if (!DateTime.TryParse(
+                    status.checked_at,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.RoundtripKind,
+                    out when))
+                return string.Empty;
+            return " Last checked " + when.ToLocalTime().ToString("g", CultureInfo.CurrentCulture) + ".";
+        }
+
+        /// <summary>
+        ///     The action the current state calls for. Every path just kicks the
+        ///     core and re-reads; the core pushes UpdateStatusChanged as the
+        ///     background job progresses.
+        /// </summary>
+        private void RunUpdateAction()
+        {
+            // Blocked on the MusicBee build: the button says Check now and means
+            // it, whatever state the core is in.
+            if (_updateBlocked)
+            {
+                _updateAction.Enabled = false;
+                _updateStatus.Text = "Checking for updates...";
+                if (!_host.CheckForUpdate()) LoadUpdateStatus();
+                return;
+            }
+
+            switch (_updateState)
+            {
+                case UpdateStates.DownloadFailed:
+                case UpdateStates.Available:
+                    _updateAction.Enabled = false;
+                    _updateStatus.Text = "Starting the download...";
+                    if (!_host.DownloadUpdate()) LoadUpdateStatus();
+                    break;
+                case UpdateStates.Staged:
+                    InstallStagedUpdate();
+                    break;
+                default:
+                    _updateAction.Enabled = false;
+                    _updateStatus.Text = "Checking for updates...";
+                    if (!_host.CheckForUpdate()) LoadUpdateStatus();
+                    break;
+            }
+        }
+
+        private void SkipUpdate()
+        {
+            _host.SkipUpdate();
+            LoadUpdateStatus();
+        }
+
+        private void OpenReleaseNotes()
+        {
+            if (string.IsNullOrEmpty(_notesUrl)) return;
+            try
+            {
+                Process.Start(new ProcessStartInfo(_notesUrl) { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                SetStatus($"Couldn't open the release notes: {ex.Message}", false);
+            }
+        }
+
+        /// <summary>
+        ///     Hand the staged update to the elevated helper, then close MusicBee -
+        ///     the helper is already waiting on this process and cannot replace
+        ///     files that are still loaded.
+        /// </summary>
+        private void InstallStagedUpdate()
+        {
+            var confirm = MessageBox.Show(
+                this,
+                "MusicBee will close so the update can be installed, then reopen.\n\n"
+                + "Windows may ask for permission to update the plugin files.\n"
+                + "Any settings changes you have not saved will be lost.",
+                "MusicBee Remote",
+                MessageBoxButtons.OKCancel,
+                MessageBoxIcon.Information);
+            if (confirm != DialogResult.OK) return;
+
+            switch (_host.ApplyStagedUpdate())
+            {
+                case Ffi.Generated.UpdateLaunch.Launched:
+                    // From here the helper owns the outcome; it waits two minutes
+                    // for this process to exit before giving up untouched.
+                    Close();
+                    CloseMusicBee();
+                    break;
+                case Ffi.Generated.UpdateLaunch.Cancelled:
+                    _updateStatus.Text =
+                        "Installation needs permission to change the plugin files. "
+                        + "The download is still there - press Install and restart to try again.";
+                    break;
+                case Ffi.Generated.UpdateLaunch.VerifyFailed:
+                    // The one outcome worth interrupting for: the staged bundle no
+                    // longer matches what the release signed.
+                    MessageBox.Show(
+                        this,
+                        "The downloaded update failed its signature check and was not installed.\n\n"
+                        + "Download it again, or install it manually from the releases page.",
+                        "MusicBee Remote",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Warning);
+                    LoadUpdateStatus();
+                    break;
+                default:
+                    _updateStatus.Text = "The update could not be started - see the log for details.";
+                    break;
+            }
+        }
+
+        /// <summary>
+        ///     Ask MusicBee's main window to close, the same way the title bar's X
+        ///     does. Posted, not sent: this runs on MusicBee's own UI thread. If it
+        ///     is configured to minimize instead of exit the process stays up and
+        ///     the helper times out having touched nothing, so the update simply
+        ///     waits for the next real exit.
+        /// </summary>
+        private void CloseMusicBee()
+        {
+            var window = _host.MusicBeeWindow;
+            if (window == IntPtr.Zero) return;
+            PostMessage(window, WM_CLOSE, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        /// <summary>
+        ///     MusicBee's build number (the third component of MusicBee.exe's file
+        ///     version, which is what its own installer gates on), or 0 when it
+        ///     cannot be read - in which case nothing is gated on it.
+        /// </summary>
+        private static int MusicBeeBuild()
+        {
+            try
+            {
+                using (var process = Process.GetCurrentProcess())
+                {
+                    return process.MainModule.FileVersionInfo.FileBuildPart;
+                }
+            }
+            catch (Exception)
+            {
+                return 0;
+            }
         }
 
         // Self-test: connect to the running server on loopback and round-trip a
@@ -673,14 +1099,27 @@ namespace MusicBeePlugin.Settings
         }
 
         // Core -> host push (raised on a background thread): marshal to the UI
-        // thread and refresh the cache line when a rebuild starts/finishes.
+        // thread and refresh the line the event is about - the cache one when a
+        // rebuild starts/finishes, the update one when a check or download does.
         private void OnCoreEvent(HostEventType e)
         {
-            if (e != HostEventType.CacheStatusChanged) return;
+            Action refresh;
+            switch (e)
+            {
+                case HostEventType.CacheStatusChanged:
+                    refresh = LoadCacheStatus;
+                    break;
+                case HostEventType.UpdateStatusChanged:
+                    refresh = LoadUpdateStatus;
+                    break;
+                default:
+                    return;
+            }
+
             if (IsDisposed || !IsHandleCreated) return;
             try
             {
-                BeginInvoke((Action)LoadCacheStatus);
+                BeginInvoke(refresh);
             }
             catch (Exception)
             {
@@ -703,6 +1142,7 @@ namespace MusicBeePlugin.Settings
                 search_source = IndexToSource(_searchSource.SelectedIndex),
                 update_firewall = _firewall.Checked,
                 log_level = IndexToLogLevel(_logLevel.SelectedIndex),
+                update_check_enabled = _autoCheck.Checked,
             };
         }
 

--- a/packages/plugin/Settings/UpdateStates.cs
+++ b/packages/plugin/Settings/UpdateStates.cs
@@ -1,0 +1,46 @@
+﻿namespace MusicBeePlugin.Settings
+{
+    /// <summary>
+    ///     The states <see cref="Ffi.UpdateStatus.state" /> can carry, mirroring
+    ///     the <c>STATE_*</c> constants in the core's <c>updates::service</c>.
+    ///     Strings rather than a generated enum: the core owns the state machine,
+    ///     and a value this side does not recognise must render as "unknown"
+    ///     rather than fail to deserialize.
+    /// </summary>
+    internal static class UpdateStates
+    {
+        /// <summary>No check has run yet and nothing is staged.</summary>
+        public const string Unknown = "unknown";
+
+        /// <summary>A check is in flight.</summary>
+        public const string Checking = "checking";
+
+        /// <summary>The published release is not newer than what is running.</summary>
+        public const string UpToDate = "up_to_date";
+
+        /// <summary>A newer release is available and not yet downloaded.</summary>
+        public const string Available = "available";
+
+        /// <summary>The available release is being downloaded and staged.</summary>
+        public const string Downloading = "downloading";
+
+        /// <summary>A verified bundle is staged and waiting for a restart.</summary>
+        public const string Staged = "staged";
+
+        /// <summary>A newer release exists but the user asked to skip this one.</summary>
+        public const string Skipped = "skipped";
+
+        /// <summary>Automatic checking is off.</summary>
+        public const string Disabled = "disabled";
+
+        /// <summary>The last check failed.</summary>
+        public const string Error = "error";
+
+        /// <summary>
+        ///     The download of an available update failed. Separate from
+        ///     <see cref="Error" />: the update is still known, so the offer is to
+        ///     retry rather than to check again.
+        /// </summary>
+        public const string DownloadFailed = "download_failed";
+    }
+}


### PR DESCRIPTION
Closes #152. This is the last open item in the auto-update epic (#24) - everything
under it (check, verify, stage, the elevated helper) was built and green, but
nothing called it. This is what does.

## How it fits together

The core owns the state machine (`updates::service`) and the panel renders it.
Check, download and skip are fire-and-forget host commands that start a
background thread; the panel reads a `HostQueryType::UpdateStatus` query and
refreshes on a `HostEventType::UpdateStatusChanged` push event. Nothing the user
presses blocks MusicBee's UI thread on a network request.

| `state` | the one action button offers |
|---|---|
| `unknown` / `up_to_date` / `skipped` / `disabled` / `error` | Check now |
| `available` | Download |
| `download_failed` | Retry download |
| `downloading` / `checking` | nothing (disabled) |
| `staged` | Install and restart |

## Automatic checking is opt-in

`default_update_check_enabled()` flips to `false`: an unprompted request to
github.com is the user's call to make. When it is on, the core runs **one** check
per session, 60s after networking starts - behind the library reconcile and the
cover-cache build, which are what MusicBee was actually opened for. "Check now"
forces a check regardless of that setting and regardless of the interval; never
being able to ask would be the other way to get this wrong.

An older `core_settings.json` gains the default off, not on: an upgrade is not
consent.

## Three rules that are not obvious from the code shape

- **A check with no news changes nothing.** A `304` (release document unchanged
  since the cached `ETag`) and a not-due check are not answers, so they rewrite
  neither the status nor the verified update behind an offer. Without this,
  pressing Check now twice would retract the Download button the first press
  produced - the second request is a `304` almost every time.
- **A failed download is its own state**, keeping the version and offering a
  retry. "No update could be found" is the wrong thing to tell someone who just
  pressed Download.
- **Only an actual offer can be skipped.** `version` is populated for
  `up_to_date` too (it names the latest published release), so skipping "whatever
  the status names" could permanently suppress the release the user is already
  running - and there is no UI to undo that.

## Smaller decisions

- A failed **check** renders as "No update could be found". An unreachable host, a
  release without a manifest and a signature that did not verify all leave the
  user with the same next move, and the core has already written the real reason
  to `mbrc-core.log`.
- `min_musicbee_build` is enforced in the panel, not the check: the core cannot
  see MusicBee's version and the panel can, reading it from `MusicBee.exe`'s file
  version - the same number the NSIS installer gates on. The button stays live as
  "Check now" rather than greying out, so a blocked release is not a dead end for
  the rest of the session.
- After `Launched`, the panel posts `WM_CLOSE` to MusicBee's main window. A
  MusicBee set to minimize on close will not exit; the helper then times out after
  two minutes having touched nothing (exit 6).
- The update jobs are detached threads that can outlive MusicBee's exit by as long
  as an HTTP request takes, so they check `state::is_initialized()` before reaching
  back into the host - `on_event` is a C# delegate that does not survive
  `mbrc_shutdown`. This narrows the window rather than closing it.

## Dialog layout

Six groups plus the footer do not fit a 720p screen, nor a 1080p one at 150%
scaling (the same thing in logical pixels), and a fixed-size window taller than
the work area puts Save off-screen with no way to reach it. The height is now
clamped to the screen work area and the group column scrolls, with Save/Close
docked outside the scrolling region.

## FFI

Additive only - `HostQueryType::UpdateStatus = 4`, `HostCommandType::{CheckForUpdate,
DownloadUpdate, SkipUpdate} = 4..6`, `HostEventType::UpdateStatusChanged = 2`, and an
`UpdateStatus` DTO. No renumbering, so `MBRC_ABI_VERSION` stays at 1. Bindings
regenerated from Rust by `build.rs`.

## Testing

Rust workspace tests and clippy green; 61 C# xUnit tests pass; `dotnet format`
clean. Live: the panel renders, "Check now" reaches github.com and reports the
current release having no `manifest.json` (expected - no release has been packaged
with the new pipeline yet).

**Not yet exercised end to end**, because it needs a release that carries a signed
manifest: check -> available -> download -> stage -> apply -> helper swap ->
relaunch. Also still owed, both needing the same: a Program Files install (the
only place the elevation path is real) and a release that replaces
`mbrc-helper.exe` itself. The `nightly` channel is the rehearsal vehicle - it hits
`releases/tags/nightly` and the manifest's channel must match, so it cannot be
served to anyone on stable.
