### PR TITLE
feat(update): replace the nightly channel with a testing one (#148)

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Full version string, e.g. 1.5.0 or 1.5.0-nightly.20260729.'
     required: true
   channel:
-    description: 'Release channel recorded in the manifest: stable or nightly.'
+    description: 'Release channel recorded in the manifest: stable or testing (published as a GitHub pre-release).'
     required: false
     default: 'stable'
   notes-url:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,13 +101,18 @@ jobs:
           name: nightly-dist-${{ needs.check.outputs.version }}
           path: build/dist
 
-      # Attestation stays off until nightlies publish to a real release
-      # (rolling `nightly` tag) rather than a 7-day workflow artifact. See #148.
+      # This job publishes a 7-day workflow artifact, not a release: there is
+      # nothing distributable to attest, and nothing that could verify it later.
+      # Attestation belongs to the path that cuts a real `testing` pre-release
+      # (#148), which should mirror release.yml - package with attest: 'true',
+      # sign the manifest, publish with --prerelease. A testing release must be
+      # signed regardless: the updater refuses a manifest it cannot verify, so an
+      # unsigned pre-release is invisible to the channel that is meant to find it.
       - name: package
         uses: ./.github/actions/package
         with:
           version: ${{ needs.build.outputs.version }}
-          channel: nightly
+          channel: testing
           attest: 'false'
 
       - name: upload artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,11 +50,16 @@ jobs:
           name: mbrc-plugin-release
           path: build/dist
 
+      # A version with a prerelease suffix (v1.6.0-rc.1) is a testing release.
+      # Everything else about it is identical to a stable one - same build, same
+      # provenance attestation, same signed manifest - because it is a real
+      # published release that people install; only the channel recorded in the
+      # manifest and the pre-release flag on the GitHub release differ.
       - name: package
         uses: ./.github/actions/package
         with:
           version: ${{ needs.build.outputs.version }}
-          channel: stable
+          channel: ${{ contains(needs.build.outputs.version, '-') && 'testing' || 'stable' }}
           attest: 'true'
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -165,6 +170,10 @@ jobs:
             build/dist/manifest.json
             build/dist/manifest.json.minisig
           generate_release_notes: true
+          # Marks it as a pre-release on GitHub, which is what keeps it out of
+          # `releases/latest` - the endpoint the stable channel follows. The
+          # testing channel lists releases instead and so still finds it.
+          prerelease: ${{ contains(needs.build.outputs.version, '-') }}
           body: |
             See the [CHANGELOG](https://github.com/musicbeeremote/mbrc-plugin/blob/main/CHANGELOG.md) for details.
 

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -66,18 +66,36 @@ The core asks GitHub for the channel's release, verifies the manifest's
 signature, and only then compares versions. Nothing is decided on unverified
 bytes and nothing is downloaded on the strength of a version number.
 
-| | stable | nightly |
+| | stable | testing |
 |---|---|---|
-| Endpoint | `releases/latest` | `releases/tags/nightly` |
-| Manifest `channel` must be | `stable` | `nightly` |
+| Endpoint | `releases/latest` | `releases?per_page=10` |
+| Follows | released versions only | releases **and** pre-releases |
+| Manifest `channel` may be | `stable` | `stable` or `testing` |
+
+`releases/latest` is GitHub's own definition of the newest release that is
+neither a draft nor a pre-release, so a pre-release cannot reach a stable user by
+GitHub's rule rather than by ours. There is no "latest including pre-releases"
+endpoint, so `testing` lists instead and takes the newest entry that is published
+and carries a manifest - skipping a draft, or a tag whose assets are still
+uploading, rather than stalling behind it.
+
+A `testing` release is cut the same way a stable one is - packaged with build
+provenance attested, its manifest signed by the release job, published with
+`--prerelease`. The signature is not optional: the updater refuses a manifest it
+cannot verify, so an unsigned pre-release is invisible to the channel meant to
+find it. The scheduled nightly workflow is the exception, and only because it
+uploads a 7-day workflow artifact rather than publishing anything.
+
+**`testing` is a superset of `stable`, not a fork of it.** It accepts a stable
+manifest as well as a testing one, so someone testing `1.6.0-rc.1` is offered
+`1.6.0` when it ships instead of being stranded on pre-releases. The version
+ordering already does the right thing: prerelease suffixes are kept, and semver
+puts `1.6.0-rc.1` below `1.6.0` and above `1.5.0`.
 
 The version the check compares against is the running plugin's, reported over FFI
 as a four-component .NET string (`1.5.0.0`). Only major.minor.patch has ever been
 meaningful here, so it is normalized to three parts before it reaches `semver`,
-which cannot parse four. Prerelease suffixes are kept, which is what makes a
-nightly order correctly: `1.7.0-nightly.20260804` is below `1.7.0` and above
-`1.6.0`, so a nightly user is offered the release it is a prerelease of and never
-an older stable.
+which cannot parse four.
 
 **Automatic checking is opt-in.** `update_check_enabled` defaults to *off*: a
 check is an unprompted outbound request to github.com, so making one is the

--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -176,7 +176,8 @@ pub struct Config {
     /// panel's "Check now" runs regardless of it.
     #[serde(default = "default_update_check_enabled")]
     pub update_check_enabled: bool,
-    /// Which release channel to follow (`stable` / `nightly`).
+    /// Which release channel to follow: `stable`, or `testing` to also be
+    /// offered pre-releases.
     #[serde(default)]
     pub update_channel: UpdateChannel,
     /// Hours between automatic checks. The panel's "Check now" ignores it.
@@ -633,17 +634,17 @@ mod tests {
         // carried rather than re-defaulted.
         let json = serde_json::to_string(&Config {
             update_check_enabled: true,
-            update_channel: UpdateChannel::Nightly,
+            update_channel: UpdateChannel::Testing,
             update_check_interval_hours: 6,
             proxy_override: "http://proxy.local:8080".into(),
             ..Config::default()
         })
         .unwrap();
-        assert!(json.contains("\"update_channel\":\"nightly\""), "{json}");
+        assert!(json.contains("\"update_channel\":\"testing\""), "{json}");
 
         let back: Config = serde_json::from_str(&json).unwrap();
         assert!(back.update_check_enabled);
-        assert_eq!(back.update_channel, UpdateChannel::Nightly);
+        assert_eq!(back.update_channel, UpdateChannel::Testing);
         assert_eq!(back.update_check_interval_hours, 6);
         assert_eq!(back.proxy_override, "http://proxy.local:8080");
 

--- a/packages/mbrc-core/src/updates/mod.rs
+++ b/packages/mbrc-core/src/updates/mod.rs
@@ -142,13 +142,13 @@ mod tests {
     #[test]
     fn options_come_from_the_settings() {
         let config = Config {
-            update_channel: Channel::Nightly,
+            update_channel: Channel::Testing,
             update_check_interval_hours: 6,
             ..Config::default()
         };
         let options = check_options(&config, "1.5.0.0", false);
         assert_eq!(options.current_version, "1.5.0.0");
-        assert_eq!(options.channel, Channel::Nightly);
+        assert_eq!(options.channel, Channel::Testing);
         assert_eq!(options.interval_hours, 6);
         assert!(!options.force);
         assert_eq!(options.repo, check::DEFAULT_REPO);

--- a/packages/mbrc-release/src/check.rs
+++ b/packages/mbrc-release/src/check.rs
@@ -27,8 +27,10 @@ pub const DEFAULT_REPO: &str = "musicbeeremote/mbrc-plugin";
 pub const MANIFEST_ASSET: &str = "manifest.json";
 pub const SIGNATURE_ASSET: &str = "manifest.json.minisig";
 
-/// The rolling tag the nightly channel tracks (#148).
-const NIGHTLY_TAG: &str = "nightly";
+/// How many releases the testing channel looks back through for one it can use.
+/// The newest is almost always the answer; the rest is slack for a release that
+/// is still being published, or a tag with no assets attached.
+const TESTING_PAGE_SIZE: u32 = 10;
 
 /// What the caller wants checked. Assembled from `Config` by the core; kept as a
 /// parameter object so the check itself stays a pure function of its inputs.
@@ -61,15 +63,21 @@ impl<'a> CheckOptions<'a> {
         }
     }
 
-    /// The GitHub API endpoint for the channel. Stable follows `releases/latest`,
-    /// which GitHub resolves to the newest non-prerelease; nightly is a fixed
-    /// rolling tag, which cannot be reached that way.
+    /// The GitHub API endpoint for the channel.
+    ///
+    /// Stable follows `releases/latest`, which GitHub resolves to the newest
+    /// release that is neither a draft nor a pre-release - so a pre-release can
+    /// never reach a stable user, by GitHub's own rule rather than by ours.
+    ///
+    /// Testing has to list instead: there is no "latest including pre-releases"
+    /// endpoint. The list comes back newest first and includes both kinds, which
+    /// is exactly the superset that channel means.
     pub fn endpoint(&self) -> String {
         let repo = self.repo;
         match self.channel {
             Channel::Stable => format!("https://api.github.com/repos/{repo}/releases/latest"),
-            Channel::Nightly => {
-                format!("https://api.github.com/repos/{repo}/releases/tags/{NIGHTLY_TAG}")
+            Channel::Testing => {
+                format!("https://api.github.com/repos/{repo}/releases?per_page={TESTING_PAGE_SIZE}")
             }
         }
     }
@@ -162,8 +170,7 @@ fn run(
         return Ok(CheckOutcome::NotModified);
     }
     let etag = response.etag.clone();
-    let release: Release = serde_json::from_slice(&response.into_body(&endpoint)?)
-        .map_err(|e| UpdateError::Parse(format!("release document: {e}")))?;
+    let release = select_release(options.channel, &response.into_body(&endpoint)?, &endpoint)?;
 
     // Signature first: the manifest's claims are worth nothing until it has been
     // shown to come from a release key.
@@ -178,10 +185,11 @@ fn run(
     .map_err(|e| UpdateError::MalformedSignature(e.to_string()))?;
     let (manifest, key_name) = verify_manifest_with(&manifest_bytes, &signature, options.keys)?;
 
-    // A manifest from the wrong channel means the tag and its assets disagree.
-    // Nightly and stable carry different expectations, so this is refused rather
-    // than quietly accepted.
-    if manifest.channel != options.channel {
+    // A manifest the subscribed channel does not accept means the release and
+    // its assets disagree, which is refused rather than quietly accepted. Note
+    // this is not equality: `testing` is a superset that takes stable releases
+    // too, so a tester is not stranded on pre-releases once the final ships.
+    if !manifest.channel.accepted_by(options.channel) {
         return Err(UpdateError::Invalid(format!(
             "{endpoint} carries a {:?} manifest but the {:?} channel was checked",
             manifest.channel, options.channel
@@ -215,12 +223,38 @@ fn run(
     })))
 }
 
+/// The release the check will act on.
+///
+/// Stable's endpoint returns exactly one; testing's returns a list, newest
+/// first, from which the first usable entry is taken. "Usable" excludes drafts
+/// (unpublished, and only visible to an authenticated request in the first
+/// place) and any release that carries no manifest - a tag published without
+/// assets, or one still being uploaded, should not stall the channel behind it.
+fn select_release(channel: Channel, body: &[u8], endpoint: &str) -> Result<Release> {
+    let parse = |e: serde_json::Error| UpdateError::Parse(format!("release document: {e}"));
+    match channel {
+        Channel::Stable => serde_json::from_slice(body).map_err(parse),
+        Channel::Testing => serde_json::from_slice::<Vec<Release>>(body)
+            .map_err(parse)?
+            .into_iter()
+            .find(|r| !r.draft && r.has_asset(MANIFEST_ASSET))
+            .ok_or_else(|| {
+                UpdateError::Invalid(format!("{endpoint} lists no release carrying a manifest"))
+            }),
+    }
+}
+
 /// The subset of GitHub's release document the updater reads. Unknown fields are
 /// ignored: this is somebody else's schema and it grows.
 #[derive(Debug, Deserialize)]
 struct Release {
     #[serde(default)]
     assets: Vec<Asset>,
+    /// Unpublished. Never present in an unauthenticated response, but the field
+    /// is read rather than assumed so a drafts-visible token cannot change what
+    /// the updater installs.
+    #[serde(default)]
+    draft: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -230,6 +264,10 @@ struct Asset {
 }
 
 impl Release {
+    fn has_asset(&self, name: &str) -> bool {
+        self.assets.iter().any(|a| a.name == name)
+    }
+
     fn asset_url(&self, name: &str) -> Result<&str> {
         self.assets
             .iter()

--- a/packages/mbrc-release/src/manifest.rs
+++ b/packages/mbrc-release/src/manifest.rs
@@ -18,11 +18,29 @@ const SHA512_HEX_LEN: usize = 128;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Channel {
-    /// Released versions. The default: nobody ends up on nightlies by omission.
+    /// Released versions. The default: nobody ends up on test builds by
+    /// omission.
     #[default]
     Stable,
-    /// The rolling `nightly` tag (#148).
-    Nightly,
+    /// Builds published for testing, as GitHub pre-releases (#148).
+    ///
+    /// This is a *superset* of stable, not a fork of it: someone on `testing`
+    /// follows the newest release of either kind, so a tester who has 1.6.0-rc.1
+    /// is offered 1.6.0 when it ships rather than being stranded on
+    /// pre-releases. The version ordering already does the right thing here -
+    /// semver puts `1.6.0-rc.1` below `1.6.0`.
+    Testing,
+}
+
+impl Channel {
+    /// Whether a manifest declaring `self` may be served to a client following
+    /// `subscribed`. Stable takes only stable; testing takes either.
+    pub fn accepted_by(self, subscribed: Channel) -> bool {
+        match subscribed {
+            Channel::Stable => self == Channel::Stable,
+            Channel::Testing => true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/packages/mbrc-release/tests/check_tests.rs
+++ b/packages/mbrc-release/tests/check_tests.rs
@@ -48,6 +48,15 @@ fn options(current: &str) -> CheckOptions<'_> {
     }
 }
 
+/// The same, following the testing channel (pre-releases included).
+fn testing(current: &str) -> CheckOptions<'_> {
+    CheckOptions {
+        repo: "test/repo",
+        keys: TEST_KEYS,
+        ..CheckOptions::new(current, Channel::Testing)
+    }
+}
+
 fn forced(current: &str) -> CheckOptions<'_> {
     CheckOptions {
         force: true,
@@ -129,46 +138,92 @@ fn a_nightly_is_never_offered_an_older_stable() {
 
 #[test]
 fn each_channel_asks_the_right_endpoint() {
+    // Stable takes GitHub's own "latest", which excludes pre-releases by its
+    // rule rather than ours. Testing has to list, because there is no "latest
+    // including pre-releases" endpoint.
     assert_eq!(
         options("1.5.0").endpoint(),
         "https://api.github.com/repos/test/repo/releases/latest"
     );
     assert_eq!(
-        CheckOptions {
-            repo: "test/repo",
-            ..CheckOptions::new("1.5.0", Channel::Nightly)
-        }
-        .endpoint(),
-        "https://api.github.com/repos/test/repo/releases/tags/nightly"
+        testing("1.5.0").endpoint(),
+        "https://api.github.com/repos/test/repo/releases?per_page=10"
     );
 }
 
 #[test]
-fn a_manifest_from_the_wrong_channel_is_refused() {
-    // The nightly tag serving the stable manifest: the tag and its assets
-    // disagree, so nothing is offered even though the version would qualify.
+fn the_channels_accept_what_they_should() {
+    // Stable takes only stable. Testing is a superset, so a tester on a
+    // pre-release is offered the final release rather than being stranded.
+    assert!(Channel::Stable.accepted_by(Channel::Stable));
+    assert!(!Channel::Testing.accepted_by(Channel::Stable));
+    assert!(Channel::Stable.accepted_by(Channel::Testing));
+    assert!(Channel::Testing.accepted_by(Channel::Testing));
+}
+
+#[test]
+fn testing_takes_the_newest_listed_release() {
+    // The list comes back newest first; the stable-channel manifest behind it is
+    // accepted, because testing follows both kinds.
     let stub = StubHttp::default();
-    stub.serve_release(API, "releases/tags/nightly", RELEASE_VERSION);
+    stub.serve_release_list(
+        API,
+        "releases?per_page=10",
+        &[(RELEASE_VERSION, false, true), ("1.4.0", false, true)],
+    );
     stub.serve("https://assets.test/manifest.json", MANIFEST.as_bytes());
     stub.serve(
         "https://assets.test/manifest.json.minisig",
         SIGNATURE.as_bytes(),
     );
+    stub.serve(
+        "https://assets.test/musicbee_remote_1.5.0.zip",
+        b"zip bytes",
+    );
 
     let mut state = UpdateState::default();
-    let error = check(
-        &stub,
-        &CheckOptions {
-            repo: "test/repo",
-            keys: TEST_KEYS,
-            ..CheckOptions::new("1.4.0.0", Channel::Nightly)
-        },
-        &mut state,
-        at(NOW),
-    )
-    .unwrap_err();
+    let outcome = check(&stub, &testing("1.4.0.0"), &mut state, at(NOW)).unwrap();
+    assert!(matches!(outcome, CheckOutcome::Available(_)), "{outcome:?}");
+}
+
+#[test]
+fn testing_skips_drafts_and_releases_without_a_manifest() {
+    // A draft is unpublished, and a tag whose assets are missing (or still
+    // uploading) must not stall the channel behind it.
+    let stub = StubHttp::default();
+    stub.serve_release_list(
+        API,
+        "releases?per_page=10",
+        &[
+            ("1.6.0", true, true),   // draft
+            ("1.5.1", false, false), // published, no manifest attached
+            (RELEASE_VERSION, false, true),
+        ],
+    );
+    stub.serve("https://assets.test/manifest.json", MANIFEST.as_bytes());
+    stub.serve(
+        "https://assets.test/manifest.json.minisig",
+        SIGNATURE.as_bytes(),
+    );
+    stub.serve(
+        "https://assets.test/musicbee_remote_1.5.0.zip",
+        b"zip bytes",
+    );
+
+    let mut state = UpdateState::default();
+    let outcome = check(&stub, &testing("1.4.0.0"), &mut state, at(NOW)).unwrap();
+    assert!(matches!(outcome, CheckOutcome::Available(_)), "{outcome:?}");
+}
+
+#[test]
+fn testing_reports_a_list_with_nothing_usable() {
+    let stub = StubHttp::default();
+    stub.serve_release_list(API, "releases?per_page=10", &[("1.6.0", true, true)]);
+
+    let mut state = UpdateState::default();
+    let error = check(&stub, &testing("1.4.0.0"), &mut state, at(NOW)).unwrap_err();
     assert!(
-        matches!(&error, UpdateError::Invalid(m) if m.contains("channel")),
+        matches!(&error, UpdateError::Invalid(m) if m.contains("no release carrying a manifest")),
         "{error:?}"
     );
 }

--- a/packages/mbrc-release/tests/support/mod.rs
+++ b/packages/mbrc-release/tests/support/mod.rs
@@ -68,6 +68,38 @@ impl StubHttp {
         );
         self.serve(&format!("{api_base}/{endpoint}"), document.as_bytes());
     }
+
+    /// The testing channel's endpoint answers with a *list*, newest first. Each
+    /// entry is `(version, draft, has_manifest)`, so a test can put a draft or an
+    /// asset-less tag in front of the release that should actually be picked.
+    pub fn serve_release_list(
+        &self,
+        api_base: &str,
+        endpoint: &str,
+        entries: &[(&str, bool, bool)],
+    ) {
+        let documents: Vec<String> = entries
+            .iter()
+            .map(|(version, draft, has_manifest)| {
+                let assets = if *has_manifest {
+                    format!(
+                        r#"{{ "name": "manifest.json", "browser_download_url": "https://assets.test/manifest.json" }},
+                           {{ "name": "manifest.json.minisig", "browser_download_url": "https://assets.test/manifest.json.minisig" }},
+                           {{ "name": "musicbee_remote_{version}.zip", "browser_download_url": "https://assets.test/musicbee_remote_{version}.zip" }}"#
+                    )
+                } else {
+                    String::new()
+                };
+                format!(
+                    r#"{{ "tag_name": "v{version}", "draft": {draft}, "assets": [{assets}] }}"#
+                )
+            })
+            .collect();
+        self.serve(
+            &format!("{api_base}/{endpoint}"),
+            format!("[{}]", documents.join(",")).as_bytes(),
+        );
+    }
 }
 
 impl HttpClient for StubHttp {


### PR DESCRIPTION
Part of #148. The second update channel followed a rolling `nightly` tag; it now
follows GitHub **pre-releases** and is called `testing`, which is what it is for -
builds published so people can try them before a release.

Doing this now costs nothing: no release has ever carried a manifest, so the
`channel` value has no compatibility burden yet. The same rename after the first
one ships would be a migration.

## Why a pre-release beats a rolling tag

Each build gets its own immutable tag and assets, so "which build am I on" has an
answer and the `ETag` means what it says. And `releases/latest` excludes
pre-releases by GitHub's own rule - a test build cannot reach a stable user
through a mistake of ours.

| | stable | testing |
|---|---|---|
| Endpoint | `releases/latest` | `releases?per_page=10` |
| Follows | released versions only | releases **and** pre-releases |
| Manifest `channel` may be | `stable` | `stable` or `testing` |

Two consequences:

- **There is no "latest including pre-releases" endpoint**, so `testing` lists
  releases (newest first) and takes the first that is published and carries a
  manifest. A draft, or a tag whose assets are still uploading, is skipped rather
  than stalling the channel behind it.
- **`testing` is a superset of `stable`, not a fork.** It accepts a stable
  manifest too, so someone on `1.6.0-rc.1` is offered `1.6.0` when it ships
  instead of being stranded on pre-releases. The channel check is now
  `Channel::accepted_by` rather than equality. Semver already orders this
  correctly: `1.6.0-rc.1` sits below `1.6.0` and above `1.5.0`.

## Releasing on the testing channel

A testing build is a real published release, so it is packaged, attested and
signed exactly like a stable one - `attest: 'true'`, the manifest signed by the
`release`-gated job, published with `--prerelease`. The signature especially: the
updater refuses a manifest it cannot verify, so an unsigned pre-release would be
invisible to the channel meant to find it.

The scheduled `nightly.yml` keeps `attest: 'false'` only because it still uploads
a 7-day workflow artifact rather than publishing anything - there is nothing
distributable to attest and nothing that could verify it later. Building that
publish path is the rest of #148; the comment there now says what it should look
like.

## Testing

`mbrc-release` integration tests cover the new selection: the endpoints per
channel, the accept matrix, taking the newest listed release, skipping drafts and
asset-less tags, and the "nothing usable in the list" error. Workspace tests and
clippy green.
