### PR TITLE
feat(discovery): advertise over mDNS / DNS-SD (#160)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ name = "mbrc-discovery"
 version = "0.1.0"
 dependencies = [
  "if-addrs",
+ "mdns-sd",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,9 +390,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -396,6 +405,15 @@ name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -452,6 +470,7 @@ dependencies = [
  "mbrc-capture",
  "mbrc-release",
  "mbrc-wire",
+ "mdns-sd",
  "memory-stats",
  "proptest",
  "redb",
@@ -512,6 +531,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba97b4c886eea3c2823388120d92063c011ac866919ffc4200a0e4b1642a54a5"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -816,6 +850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +959,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612942246d0cc239cfd83af1dfd39be47f649208a3524e5e9da651910128e0ac"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +977,15 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -2080,3 +2080,53 @@ MusicBee Remote supports UDP multicast for service discovery on the local networ
 
 Clients can listen for discovery broadcasts to find available MusicBee instances without
 manual configuration. Discovery is a separate UDP path, independent of the TCP command socket.
+
+The probe carries the client's own address, and the reply names the server interface on the
+*same subnet* - which is what makes a multi-NIC host (Hyper-V, WSL, VirtualBox, Docker) hand
+back an address the phone can actually reach.
+
+### mDNS / DNS-SD
+
+The plugin **also** advertises itself over mDNS, additive to the above. Nothing about the
+custom responder changes, and every shipped client keeps working untouched; this exists so
+that anything not written against our protocol - `NsdManager`, `NWBrowser`, `dns-sd -B`,
+Avahi, a Bonjour browser - can find a MusicBee host.
+
+```
+_mbrc._tcp.local.
+```
+
+| | |
+|---|---|
+| Instance name | the machine name (same one the custom responder reports) |
+| SRV port | the TCP command port |
+| A records | the host's usable IPv4 addresses (loopback and `169.254` link-local dropped) |
+
+TXT records:
+
+| key | example | meaning |
+|---|---|---|
+| `protocol` | `4,5` | handshake versions this server accepts, comma-separated |
+| `version` | `1.5.0` | the plugin's release version |
+| `name` | `LIVING-ROOM-PC` | friendly name; the instance name is DNS-escaped, this is not |
+
+**`protocol` is advisory.** It lets a client that speaks only one version filter before
+connecting, but the handshake remains authoritative - never refuse a server because its TXT
+looked wrong.
+
+Unlike the custom probe, mDNS carries no client-subnet hint, so the record lists every usable
+address and the client picks. On a host with virtual adapters that may include an address
+your client cannot reach; try them in order rather than trusting the first.
+
+Instance-name collisions are resolved by mDNS itself (it suffixes), so two MusicBee hosts on
+one LAN need no coordination. A goodbye packet is sent on shutdown, so a stopped server
+disappears from browsers immediately rather than at TTL expiry.
+
+Advertising can be turned off (`mdns_enabled`, Configure panel → Connection → Discovery); the
+custom responder is unaffected.
+
+Client-side notes: Android needs a `MulticastLock` held while browsing (without it the Wi-Fi
+chipset filters the traffic and discovery silently finds nothing) plus
+`CHANGE_WIFI_MULTICAST_STATE`; iOS needs `NSBonjourServices` and `NSLocalNetworkUsageDescription`
+in `Info.plist` or browsing returns empty with no error. Bonjour browsing needs no entitlement,
+whereas joining our custom multicast group on iOS would require Apple's multicast entitlement.

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -51,6 +51,11 @@ mbrc-release = { workspace = true, features = ["client"] }
 time = { workspace = true }
 if-addrs = { workspace = true }
 socket2 = "=0.6.4"
+# mDNS / DNS-SD advertisement (#160), additive to the custom UDP responder. Pure
+# Rust with no async-runtime dependency of its own - it runs its own daemon
+# thread - so i686-msvc stays free of a C toolchain. `logging` is left off: the
+# crate would pull in `log`, and the core's logging goes through `tracing`.
+mdns-sd = { version = "=0.21.0", default-features = false }
 
 # ShellExecuteExW (the elevation prompt for the update helper) and the loader
 # calls that answer "which directory was this DLL loaded from", which is how the

--- a/packages/mbrc-core/src/config.rs
+++ b/packages/mbrc-core/src/config.rs
@@ -95,6 +95,13 @@ fn default_tcp_keepalive_secs() -> u64 {
     45
 }
 
+/// On. The custom UDP responder already multicasts, so this adds a standard way
+/// to be found rather than a new kind of chatter, and being findable is the
+/// point of a remote-control plugin.
+fn default_mdns_enabled() -> bool {
+    true
+}
+
 /// Off. An automatic check is an unprompted outbound request to github.com, so
 /// it is the user's call to make, not ours to assume. The panel's "Check now"
 /// works whatever this says - never being able to ask would be the other way to
@@ -171,6 +178,11 @@ pub struct Config {
     /// the kernel detects and drops dead half-open connections.
     #[serde(default = "default_tcp_keepalive_secs")]
     pub tcp_keepalive_secs: u64,
+    /// Whether to advertise over mDNS / DNS-SD as well as the custom UDP
+    /// responder. Additive: turning it off leaves every shipped client working,
+    /// which is why it can be a preference at all.
+    #[serde(default = "default_mdns_enabled")]
+    pub mdns_enabled: bool,
     /// Whether the core checks for plugin updates *on its own*. A check is a
     /// request to github.com, so it is opt-in: this defaults to off, and the
     /// panel's "Check now" runs regardless of it.
@@ -233,6 +245,7 @@ impl Default for Config {
             max_conns_per_client: default_max_conns_per_client(),
             max_conns_per_ip: default_max_conns_per_ip(),
             tcp_keepalive_secs: default_tcp_keepalive_secs(),
+            mdns_enabled: default_mdns_enabled(),
             update_check_enabled: default_update_check_enabled(),
             update_channel: UpdateChannel::default(),
             update_check_interval_hours: default_update_check_interval_hours(),

--- a/packages/mbrc-core/src/discovery.rs
+++ b/packages/mbrc-core/src/discovery.rs
@@ -51,7 +51,10 @@ pub async fn run(tcp_port: u16, shutdown: Arc<Notify>) {
 /// The device name advertised to clients - this host's machine name. On Windows
 /// `COMPUTERNAME` is the equivalent of the shipped plugin's
 /// `Environment.MachineName`; fall back to a generic label if unset.
-fn hostname() -> String {
+///
+/// Shared with the mDNS advertisement, so both mechanisms name this host the
+/// same way in a picker.
+pub(crate) fn hostname() -> String {
     std::env::var("COMPUTERNAME")
         .or_else(|_| std::env::var("HOSTNAME"))
         .ok()

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod cover;
 pub mod discovery;
 pub mod ffi;
 pub mod logging;
+pub mod mdns;
 pub mod metadata_cache;
 pub mod nowplaying;
 pub mod protocol;

--- a/packages/mbrc-core/src/mdns.rs
+++ b/packages/mbrc-core/src/mdns.rs
@@ -1,0 +1,319 @@
+//! mDNS / DNS-SD advertisement, alongside the custom UDP responder (#160).
+//!
+//! [`discovery`](crate::discovery) is not going anywhere - every shipped client
+//! depends on it. What it cannot do is be found by anything not written against
+//! it, and both mobile platforms have DNS-SD browsing built in (`NsdManager`,
+//! `NWBrowser`), as does every diagnostic tool on the LAN. This publishes the
+//! same facts through the standard mechanism.
+//!
+//! Four things here are deliberate:
+//!
+//! - **Best-effort, exactly like the custom responder.** A daemon that will not
+//!   start, or a registration that is refused, logs a warning and leaves. Failing
+//!   to advertise must never be able to stop the plugin serving clients.
+//! - **A list of services, not one.** DNS-SD is per-service and one daemon can
+//!   hold several, so a second endpoint later (an HTTP server, say) is another
+//!   entry here rather than a rewrite.
+//! - **The addresses are ours, not the crate's.** `mdns-sd` can fill in every
+//!   address it finds; we hand it [`usable_ipv4_ifaces`] instead, so what is
+//!   advertised is the same set the panel's "Reachable at" row shows. mDNS has
+//!   no client-subnet hint, so unlike the custom responder we cannot pick *the*
+//!   reachable address - but we can at least not publish loopback and APIPA.
+//! - **Goodbye on the way out.** A stale instance sitting in every browser on the
+//!   LAN until its TTL expires is worse than never having advertised.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use mdns_sd::{ServiceDaemon, ServiceInfo};
+use tokio::sync::Notify;
+
+use crate::discovery::usable_ipv4_ifaces;
+use crate::protocol::version::SUPPORTED_VERSIONS;
+
+/// The service type clients browse for.
+///
+/// Four characters, well inside the fifteen RFC 6763 allows for a service name -
+/// `_musicbee-remote` would have sat exactly on the limit with no headroom. What
+/// a person reads in a picker is the *instance* name, which is this machine's
+/// name, so the type does not have to carry the branding. It also leaves room
+/// for a sibling type later: `_mbrc-http._tcp` fits, `_musicbeeremote-http`
+/// would not.
+///
+/// **Permanent.** Once a client ships against it, changing it makes that client
+/// blind to every server that follows us.
+pub const SERVICE_TYPE: &str = "_mbrc._tcp.local.";
+
+/// How often the interface set is re-checked. mDNS advertises addresses, so a
+/// laptop moving from Wi-Fi to a dock has to re-register or it is advertising
+/// somewhere it no longer is. Slow enough to be free, quick enough that nobody
+/// waits on it.
+const INTERFACE_POLL: Duration = Duration::from_secs(30);
+
+/// How long to give the goodbye packet before tearing the daemon down.
+const GOODBYE_GRACE: Duration = Duration::from_millis(500);
+
+/// One thing to advertise. Today there is exactly one; the shape is here so a
+/// second endpoint is an entry rather than a redesign.
+struct Service {
+    service_type: &'static str,
+    port: u16,
+    txt: HashMap<String, String>,
+}
+
+/// Advertise until `shutdown` is signalled, then withdraw.
+pub async fn run(tcp_port: u16, shutdown: Arc<Notify>) {
+    let daemon = match ServiceDaemon::new() {
+        Ok(daemon) => daemon,
+        Err(e) => {
+            tracing::warn!(error = %e, "mDNS disabled (daemon failed to start)");
+            return;
+        }
+    };
+
+    let instance = instance_name();
+    let mut addresses = advertised_addresses();
+    if addresses.is_empty() {
+        // Nothing to point anyone at. Not fatal - an interface may appear later,
+        // and the poll below will pick it up.
+        tracing::debug!("mDNS has no advertisable address yet");
+    }
+
+    let services = services(tcp_port);
+    let mut registered = register_all(&daemon, &instance, &addresses, &services);
+    tracing::info!(
+        instance = %instance,
+        service = SERVICE_TYPE,
+        port = tcp_port,
+        addresses = addresses.len(),
+        "mDNS advertisement started"
+    );
+
+    // Pinned once outside the loop rather than created per iteration: `Notify`
+    // wakes the waiters registered at the moment it fires and stores nothing, so
+    // a notification arriving while this task was busy re-registering would be
+    // missed by a fresh `notified()` - and a missed shutdown here leaks the
+    // daemon thread, which would go on advertising a server that has stopped.
+    let notified = shutdown.notified();
+    tokio::pin!(notified);
+
+    loop {
+        tokio::select! {
+            _ = &mut notified => break,
+            _ = tokio::time::sleep(INTERFACE_POLL) => {
+                let current = advertised_addresses();
+                if current == addresses {
+                    continue;
+                }
+                tracing::info!(
+                    was = addresses.len(),
+                    now = current.len(),
+                    "mDNS re-registering (the interface set changed)"
+                );
+                withdraw(&daemon, &registered).await;
+                addresses = current;
+                registered = register_all(&daemon, &instance, &addresses, &services);
+            }
+        }
+    }
+
+    withdraw(&daemon, &registered).await;
+    if let Err(e) = daemon.shutdown() {
+        tracing::debug!(error = %e, "mDNS daemon shutdown failed");
+    }
+    tracing::info!("mDNS advertisement stopped");
+}
+
+/// What this host publishes. The TXT keys are identity plus one advisory hint:
+/// `protocol` lets a client that only speaks one version filter before
+/// connecting, but the handshake stays authoritative - a stale TXT must never be
+/// able to talk a client out of a server it could have used.
+fn services(tcp_port: u16) -> Vec<Service> {
+    let mut txt = HashMap::new();
+    txt.insert("protocol".to_owned(), advertised_protocols());
+    txt.insert(
+        "version".to_owned(),
+        crate::updates::CORE_VERSION.to_owned(),
+    );
+    txt.insert("name".to_owned(), crate::discovery::hostname());
+
+    vec![Service {
+        service_type: SERVICE_TYPE,
+        port: tcp_port,
+        txt,
+    }]
+}
+
+/// The handshake versions this core accepts, comma-separated (`"4,5"`).
+fn advertised_protocols() -> String {
+    SUPPORTED_VERSIONS
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Register everything, returning the full names of what actually took. A
+/// registration that fails is logged and skipped rather than aborting the rest:
+/// one bad service should not cost the others.
+fn register_all(
+    daemon: &ServiceDaemon,
+    instance: &str,
+    addresses: &[IpAddr],
+    services: &[Service],
+) -> Vec<String> {
+    services
+        .iter()
+        .filter_map(|service| match info(service, instance, addresses) {
+            Ok(info) => {
+                let fullname = info.get_fullname().to_owned();
+                match daemon.register(info) {
+                    Ok(()) => Some(fullname),
+                    Err(e) => {
+                        tracing::warn!(error = %e, service = service.service_type, "mDNS registration refused");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, service = service.service_type, "mDNS service record rejected");
+                None
+            }
+        })
+        .collect()
+}
+
+/// Build one service record. The host name is this machine under `.local.`,
+/// which is what the SRV record points at and what the A records answer for.
+fn info(service: &Service, instance: &str, addresses: &[IpAddr]) -> mdns_sd::Result<ServiceInfo> {
+    ServiceInfo::new(
+        service.service_type,
+        instance,
+        &host_name(instance),
+        addresses,
+        service.port,
+        Some(service.txt.clone()),
+    )
+}
+
+/// Send the goodbye packets and give them a moment to leave, so browsers drop
+/// the instance now rather than when its TTL runs out.
+async fn withdraw(daemon: &ServiceDaemon, registered: &[String]) {
+    if registered.is_empty() {
+        return;
+    }
+    for fullname in registered {
+        match daemon.unregister(fullname) {
+            Ok(_) => tracing::debug!(%fullname, "mDNS goodbye sent"),
+            Err(e) => tracing::debug!(%fullname, error = %e, "mDNS unregister failed"),
+        }
+    }
+    tokio::time::sleep(GOODBYE_GRACE).await;
+}
+
+/// The instance name browsers show. The machine name, as the custom responder
+/// already uses - mDNS resolves collisions itself by suffixing, so two MusicBee
+/// hosts on one LAN need nothing from us.
+fn instance_name() -> String {
+    crate::discovery::hostname()
+}
+
+/// The `.local.` host name for the SRV target, derived from the instance name.
+/// Anything that is not a DNS label character becomes `-`: a machine name is
+/// free-form, a host name is not.
+fn host_name(instance: &str) -> String {
+    let sanitized: String = instance
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('-');
+    let label = if trimmed.is_empty() {
+        "musicbee"
+    } else {
+        trimmed
+    };
+    format!("{label}.local.")
+}
+
+/// The addresses to publish: the same set the custom responder considers and the
+/// settings panel lists, so "where can this be reached" has one answer.
+fn advertised_addresses() -> Vec<IpAddr> {
+    usable_ipv4_ifaces()
+        .into_iter()
+        .map(|(ip, _mask)| IpAddr::V4(ip))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Nothing here starts a ServiceDaemon: that would bind UDP 5353 and emit
+    // multicast, which on Windows means a firewall prompt and a stale rule per
+    // test binary. Building the records proves the shape; the daemon is proved
+    // by running the plugin.
+
+    #[test]
+    fn the_service_type_fits_the_dns_sd_limit() {
+        // RFC 6763 allows at most 15 characters in a service name, underscore
+        // excluded. This is the value clients ship against, so it is pinned by a
+        // test rather than left to a careless edit.
+        let name = SERVICE_TYPE
+            .strip_prefix('_')
+            .and_then(|s| s.split('.').next())
+            .expect("a leading-underscore service label");
+        assert_eq!(name, "mbrc");
+        assert!(name.len() <= 15, "{name} is {} characters", name.len());
+        assert!(SERVICE_TYPE.ends_with("._tcp.local."));
+    }
+
+    #[test]
+    fn the_record_carries_the_port_and_the_txt_keys() {
+        let services = services(3000);
+        let service = services.first().expect("one service today");
+        assert_eq!(service.port, 3000);
+        assert_eq!(service.txt.get("protocol").map(String::as_str), Some("4,5"));
+        assert!(service.txt.contains_key("version"));
+        assert!(service.txt.contains_key("name"));
+        // `path` is reserved by DNS-SD convention for HTTP-ish types; publishing
+        // one here would mean something we do not mean.
+        assert!(!service.txt.contains_key("path"));
+    }
+
+    #[test]
+    fn the_advertised_protocols_are_the_supported_ones() {
+        let advertised: Vec<u8> = advertised_protocols()
+            .split(',')
+            .map(|v| v.parse().expect("a numeric version"))
+            .collect();
+        assert_eq!(advertised, SUPPORTED_VERSIONS);
+    }
+
+    #[test]
+    fn host_names_are_dns_labels() {
+        assert_eq!(host_name("LIVING-ROOM-PC"), "LIVING-ROOM-PC.local.");
+        // A machine name is free-form; a host name is not.
+        assert_eq!(host_name("Kelsos' PC"), "Kelsos--PC.local.");
+        assert_eq!(host_name("_"), "musicbee.local.");
+        assert_eq!(host_name(""), "musicbee.local.");
+    }
+
+    #[test]
+    fn a_record_builds_from_real_inputs() {
+        let services = services(3000);
+        let addresses = vec![IpAddr::V4("192.168.1.20".parse().unwrap())];
+        let info = info(&services[0], "TEST-PC", &addresses).expect("a valid record");
+        assert_eq!(info.get_port(), 3000);
+        assert_eq!(info.get_hostname(), "TEST-PC.local.");
+        assert!(info.get_fullname().starts_with("TEST-PC."));
+        assert!(info.get_fullname().ends_with(SERVICE_TYPE));
+    }
+}

--- a/packages/mbrc-core/src/protocol/version.rs
+++ b/packages/mbrc-core/src/protocol/version.rs
@@ -17,6 +17,14 @@ pub enum ProtocolVersion {
     // V6 is reserved: add the variant + a `wire::v6` formatter and map it below.
 }
 
+/// Every handshake version the core accepts, low to high.
+///
+/// Exists so anything that has to *state* what is supported - the mDNS TXT
+/// record, and whatever else advertises later - reads it from here instead of
+/// carrying its own list that quietly goes stale when a version is added. The
+/// test below pins it to what [`ProtocolVersion::from_negotiated`] will accept.
+pub const SUPPORTED_VERSIONS: &[u8] = &[4, 5];
+
 impl ProtocolVersion {
     /// Map a negotiated handshake version number to a formatter version, or
     /// `None` if unsupported (the handshake already rejects pre-V4).
@@ -40,5 +48,30 @@ impl ProtocolVersion {
     /// (V5+ only; it never fires in a V4 session).
     pub fn accepts_current_position(self) -> bool {
         matches!(self, Self::V5)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_advertised_versions_are_the_accepted_ones() {
+        // The list exists to be published (mDNS TXT). If it ever disagrees with
+        // what the handshake accepts, clients are told something untrue.
+        for &version in SUPPORTED_VERSIONS {
+            assert!(
+                ProtocolVersion::from_negotiated(version).is_some(),
+                "version {version} is advertised but not accepted"
+            );
+        }
+        for version in 0u8..=10 {
+            if ProtocolVersion::from_negotiated(version).is_some() {
+                assert!(
+                    SUPPORTED_VERSIONS.contains(&version),
+                    "version {version} is accepted but not advertised"
+                );
+            }
+        }
     }
 }

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -27,6 +27,11 @@ use crate::state::Core;
 /// the answer already there.
 const STARTUP_UPDATE_CHECK_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// How long networking shutdown waits for the mDNS advertisement to withdraw.
+/// Long enough for the goodbye packets to leave, short enough that a wedged
+/// daemon cannot hold up MusicBee closing.
+const MDNS_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Handle to a running networking stack. Call [`NetHandle::stop`] to shut it
 /// down and join the server thread.
 pub struct NetHandle {
@@ -132,6 +137,22 @@ fn run_thread(
                 shutdown.clone(),
             )))
         };
+        // The standard way to be found, additive to the responder above (#160).
+        // Same loopback rule and for the same two reasons: nothing off-box can
+        // reach a loopback listener, and binding 5353 on a test run would raise
+        // the firewall prompt this suite exists without.
+        let mdns = if bind_ip.is_loopback() || !core.config.mdns_enabled {
+            tracing::debug!(
+                enabled = core.config.mdns_enabled,
+                "mDNS advertisement skipped"
+            );
+            None
+        } else {
+            Some(tokio::spawn(crate::mdns::run(
+                core.config.port,
+                shutdown.clone(),
+            )))
+        };
         let monitor = tokio::spawn(monitor::run(core.clone(), shutdown.clone()));
         let scanner = tokio::spawn(scanner::run(core.clone(), shutdown.clone()));
 
@@ -171,6 +192,19 @@ fn run_thread(
         }
         if let Some(discovery) = discovery {
             discovery.abort();
+        }
+        // Awaited rather than aborted, unlike everything else here: it has a
+        // shutdown path - the goodbye packets that get this host out of every
+        // browser on the LAN - and the whole point of sending them is that they
+        // arrive. Bounded, because a task that will not finish must not be able
+        // to hold MusicBee's shutdown.
+        if let Some(mdns) = mdns {
+            if tokio::time::timeout(MDNS_SHUTDOWN_GRACE, mdns)
+                .await
+                .is_err()
+            {
+                tracing::warn!("mDNS did not withdraw in time");
+            }
         }
         monitor.abort();
         scanner.abort();

--- a/packages/mbrc-discovery/Cargo.toml
+++ b/packages/mbrc-discovery/Cargo.toml
@@ -9,3 +9,6 @@ description = "Client-side UDP-multicast discovery of MusicBee Remote plugin ins
 serde = { workspace = true }
 serde_json = { workspace = true }
 if-addrs = { workspace = true }
+# DNS-SD browsing for the mDNS advertisement (#160). Same crate the plugin
+# advertises with, so what this sees is what it publishes.
+mdns-sd = { version = "=0.21.0", default-features = false }

--- a/packages/mbrc-discovery/src/lib.rs
+++ b/packages/mbrc-discovery/src/lib.rs
@@ -68,6 +68,67 @@ fn open_and_send(iface: Ipv4Addr) -> std::io::Result<UdpSocket> {
     Ok(socket)
 }
 
+/// The DNS-SD service type the plugin advertises (#160), alongside the custom
+/// protocol above. Must match `mbrc_core::mdns::SERVICE_TYPE`; the two crates do
+/// not share a dependency, the same way the multicast constants above are
+/// mirrored rather than shared.
+pub const MDNS_SERVICE_TYPE: &str = "_mbrc._tcp.local.";
+
+/// Blocking mDNS browse: collect the plugin instances that answer a DNS-SD query
+/// until `timeout` elapses.
+///
+/// The other half of [`discover_blocking`], and useful for the same reason a
+/// browser is: it answers "is this host advertising, and with what?" without a
+/// packet capture. Where the custom probe returns the one address matching the
+/// client's subnet, this returns whatever the record lists - mDNS has no
+/// subnet hint - so a multi-NIC host can yield several entries for one machine.
+pub fn browse_mdns_blocking(timeout: Duration) -> Result<Vec<Discovered>, String> {
+    let daemon = mdns_sd::ServiceDaemon::new().map_err(|e| format!("mDNS daemon: {e}"))?;
+    let receiver = daemon
+        .browse(MDNS_SERVICE_TYPE)
+        .map_err(|e| format!("mDNS browse: {e}"))?;
+
+    let mut found: Vec<Discovered> = Vec::new();
+    let deadline = Instant::now() + timeout;
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        match receiver.recv_timeout(remaining) {
+            Ok(mdns_sd::ServiceEvent::ServiceResolved(info)) => {
+                let name = info
+                    .get_property_val_str("name")
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| instance_of(info.get_fullname()));
+                for address in info.get_addresses() {
+                    let entry = Discovered {
+                        address: address.to_string(),
+                        port: info.get_port(),
+                        name: name.clone(),
+                    };
+                    if !found
+                        .iter()
+                        .any(|d| d.address == entry.address && d.port == entry.port)
+                    {
+                        found.push(entry);
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+    let _ = daemon.shutdown();
+    Ok(found)
+}
+
+/// The instance label out of a DNS-SD full name (`INSTANCE._mbrc._tcp.local.`),
+/// for when the record carries no `name` in TXT.
+fn instance_of(fullname: &str) -> String {
+    fullname
+        .strip_suffix(MDNS_SERVICE_TYPE)
+        .and_then(|s| s.strip_suffix('.'))
+        .unwrap_or(fullname)
+        .to_owned()
+}
+
 /// Blocking discovery: probe every interface and collect distinct replies until
 /// `timeout` elapses. Runs on the calling thread.
 pub fn discover_blocking(timeout: Duration) -> Result<Vec<Discovered>, String> {
@@ -159,6 +220,14 @@ mod tests {
             parse_notify(br#"{"context":"notify","address":"10.0.0.2"}"#).expect("should parse");
         assert_eq!(d.port, 3000);
         assert_eq!(d.name, "MusicBee Remote");
+    }
+
+    #[test]
+    fn instance_label_is_taken_from_the_full_name() {
+        assert_eq!(instance_of("THOTH._mbrc._tcp.local."), "THOTH");
+        // Anything that is not the expected shape is passed through rather than
+        // mangled: a label is better than an empty name.
+        assert_eq!(instance_of("odd-name"), "odd-name");
     }
 
     #[test]

--- a/packages/plugin/Settings/CoreSettings.cs
+++ b/packages/plugin/Settings/CoreSettings.cs
@@ -35,6 +35,13 @@ namespace MusicBeePlugin.Settings
         public string log_level { get; set; } = "info";
 
         /// <summary>
+        ///     Whether the plugin also advertises itself over mDNS / DNS-SD
+        ///     (Bonjour). Additive to the custom UDP discovery, which is
+        ///     unaffected either way, so this is safe to turn off.
+        /// </summary>
+        public bool mdns_enabled { get; set; } = true;
+
+        /// <summary>
         ///     Whether the core checks for a newer release on its own. Off by
         ///     default: an automatic check is an unprompted request to github.com.
         ///     The panel's "Check now" button works regardless of this.

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -86,6 +86,7 @@ namespace MusicBeePlugin.Settings
         private ComboBox _searchSource;
         private ComboBox _logLevel;
         private CheckBox _firewall;
+        private CheckBox _mdns;
         private Label _status;
         private Label _cacheStatus;
         private System.Windows.Forms.Timer _blockedTimer;
@@ -285,10 +286,21 @@ namespace MusicBeePlugin.Settings
                 ForeColor = SystemColors.GrayText,
             };
 
+            // Additive to the custom UDP discovery every shipped client uses, so
+            // clearing it costs nothing those clients depend on - it only stops
+            // the plugin appearing in Bonjour/NsdManager browsers.
+            _mdns = new CheckBox
+            {
+                Text = "Also advertise over mDNS (Bonjour)",
+                AutoSize = true,
+                Anchor = AnchorStyles.Left,
+            };
+
             var layout = GroupLayout();
             AddRow(layout, "Listening port", _port);
             AddRow(layout, "Status", statusRow);
             AddRow(layout, "Reachable at", _addresses);
+            AddRow(layout, "Discovery", _mdns);
             return WrapGroup("Connection", layout);
         }
 
@@ -663,6 +675,7 @@ namespace MusicBeePlugin.Settings
             _searchSource.SelectedIndex = SourceToIndex(s.search_source);
             _logLevel.SelectedIndex = LogLevelToIndex(s.log_level);
             _firewall.Checked = s.update_firewall;
+            _mdns.Checked = s.mdns_enabled;
             _autoCheck.Checked = s.update_check_enabled;
             UpdateFilterEnabled();
             SetStatus(string.Empty, true);
@@ -1141,6 +1154,7 @@ namespace MusicBeePlugin.Settings
                     .ToList(),
                 search_source = IndexToSource(_searchSource.SelectedIndex),
                 update_firewall = _firewall.Checked,
+                mdns_enabled = _mdns.Checked,
                 log_level = IndexToLogLevel(_logLevel.SelectedIndex),
                 update_check_enabled = _autoCheck.Checked,
             };

--- a/tools/api-debugger/src-tauri/Cargo.lock
+++ b/tools/api-debugger/src-tauri/Cargo.lock
@@ -989,6 +989,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -1977,6 +1986,7 @@ name = "mbrc-discovery"
 version = "0.1.0"
 dependencies = [
  "if-addrs",
+ "mdns-sd",
  "serde",
  "serde_json",
 ]
@@ -1987,6 +1997,20 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "mdns-sd"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba97b4c886eea3c2823388120d92063c011ac866919ffc4200a0e4b1642a54a5"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
 ]
 
 [[package]]
@@ -2027,6 +2051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3123,6 +3148,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612942246d0cc239cfd83af1dfd39be47f649208a3524e5e9da651910128e0ac"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3178,6 +3214,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/tools/mbrc-cli/src/main.rs
+++ b/tools/mbrc-cli/src/main.rs
@@ -59,7 +59,15 @@ fn cmd_discover(args: &[String]) -> ExitCode {
         }
     };
     let timeout = Duration::from_millis(timeout_ms.clamp(500, 10_000));
-    match mbrc_discovery::discover_blocking(timeout) {
+    // `--mdns` browses the DNS-SD advertisement instead of the custom protocol.
+    // Both answer "who is out there", and comparing them is the fastest way to
+    // tell a plugin that is not running from one that is not being *found*.
+    let result = if args::has_flag(args, "--mdns") {
+        mbrc_discovery::browse_mdns_blocking(timeout)
+    } else {
+        mbrc_discovery::discover_blocking(timeout)
+    };
+    match result {
         Ok(found) => {
             if found.is_empty() {
                 println!("no instances found");
@@ -84,7 +92,8 @@ fn print_usage() {
          \x20 mbrc <command> [options]\n\
          \n\
          COMMANDS:\n\
-         \x20 discover [--timeout-ms N]                 find plugin instances on the LAN\n\
+         \x20 discover [--timeout-ms N] [--mdns]        find plugin instances on the LAN\n\
+         \x20                                           (--mdns browses DNS-SD instead)\n\
          \x20 inspect  <capture.jsonl>                  summarise an mbrc-capture/2 trace\n\
          \x20 send     [--host H] [--port P] [--json C] connect, handshake, send a command\n\
          \x20          [--client-type T] [--protocol V] [--no-broadcast] [--wait-ms N]\n\


### PR DESCRIPTION
Closes #160. The plugin now advertises itself over mDNS / DNS-SD **in addition
to** the custom UDP responder, which does not change in any way.

## Decisions taken (the three the issue parked)

**1. Service type: `_mbrc._tcp`.** Four characters against the fifteen RFC 6763
allows for a service name - `_musicbee-remote` would have sat exactly on the
limit with no headroom. What a person reads in a picker is the *instance* name,
which is the machine name, so the type does not need to carry the branding. It
also leaves room for a sibling type later: `_mbrc-http._tcp` fits comfortably,
`_musicbeeremote-http` would be illegal at 19 characters. **Permanent once a
client ships against it.**

**2. TXT carries `protocol`, advisory only.** `protocol=4,5`, plus `version` and
`name`. It lets a client that speaks one version filter before connecting, but
the handshake stays authoritative - a stale TXT must never be able to talk a
client out of a server it could have used. The value comes from a new
`SUPPORTED_VERSIONS` in `protocol::version`, pinned by a test to exactly what
`ProtocolVersion::from_negotiated` accepts, so it cannot quietly go stale when V6
lands.

**3. Addresses: the `usable_ipv4_ifaces()` set.** `mdns-sd` would happily publish
every address it finds; it gets ours instead - the same list the panel's
"Reachable at" row shows, with loopback and `169.254` link-local dropped. mDNS
carries no client-subnet hint, so unlike the custom probe we cannot pick *the*
reachable address; we can at least decline to publish ones nobody can use.

IANA registration (the issue's fourth question) is not done and is not required.

## Implementation notes

- **Best-effort, exactly like the custom responder.** A daemon that will not
  start, or a registration that is refused, logs a warning and leaves. Advertising
  must never be able to stop the plugin serving clients.
- **A list of services, not one.** DNS-SD is per-service and a daemon can hold
  several, so a second endpoint later is another entry rather than a rewrite.
- **Goodbye packets on shutdown**, and networking shutdown *awaits* the task
  (bounded at 2s) rather than aborting it - the point of sending them is that they
  arrive. A stale instance in every browser on the LAN until its TTL expires is
  worse than never having advertised.
- **The shutdown future is pinned outside the select loop.** `Notify` wakes the
  waiters registered at the moment it fires and stores nothing, so a notification
  arriving while the task was mid re-registration would be missed by a fresh
  `notified()` - and a missed shutdown here leaks the daemon thread, which would
  go on advertising a server that had stopped.
- **Re-registration on interface change**, polled every 30s: mDNS advertises
  addresses, so a laptop moving from Wi-Fi to a dock is otherwise advertising
  somewhere it no longer is. A port change already re-registers, because changing
  it reloads the core.
- Skipped when bound to loopback, for the same two reasons discovery is: nothing
  off-box can reach it, and binding 5353 during a test run would raise the Windows
  Firewall prompt the suite exists without.

`mdns_enabled` defaults **on**, with a checkbox in Configure → Connection →
Discovery. Turning it off leaves every shipped client working, which is what makes
it safe to be a preference at all.

## Crate

`mdns-sd` `=0.21.0`, default features off (its `logging` feature would pull in
`log`; the core is `tracing`). Dependency tree inspected and i686-clean - fastrand,
flume, if-addrs (the version already in the tree), mio, socket-pktinfo, socket2.
No C toolchain.

## Testing

Six unit tests: the service type against the RFC 6763 limit, the TXT keys and
port, advertised-vs-accepted protocol versions, host-name sanitisation, and
building a real `ServiceInfo`. **None of them starts a `ServiceDaemon`** - that
would bind UDP 5353 and emit multicast, which on Windows means a firewall prompt
and a stale rule per test binary. 179 core tests pass, clippy clean,
`dotnet format` clean.

## Not covered, and worth settling before this is trusted

- **Windows has held UDP 5353 since Win10** with its own mDNS responder. `mdns-sd`
  sets address reuse, but this needs a live check on a machine with the OS
  responder active rather than an assumption. It is the single most likely reason
  a first implementation works on one machine and not another.
- **The firewall rule is TCP-only.** `mbrc-helper`'s `ensure_rule` sets
  `NET_FW_IP_PROTOCOL_TCP` for the command port, so neither UDP 5353 nor the
  existing UDP 45345 is in it. Worth confirming how the custom discovery gets
  through today - most likely a per-application allow from a first-run prompt -
  because mDNS needs the same treatment.
