### PR TITLE
fix(update): close three gaps found reviewing the update mechanism

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -211,6 +211,13 @@ replaced" - and one generation is kept. A failed write restores them. A restore
 that cannot put back a file whose installed copy is already identical to the
 backup is not a failure: that file was never replaced.
 
+**The restore writes from memory, not from that directory.** The backup lives
+under the user's profile, so an unelevated process can rewrite it while the
+elevated apply is running; reading it back would turn that write into an elevated
+one. The bytes read during the backup are what get restored, for the same reason
+the payload is verified in memory rather than re-read from disk. The on-disk copy
+remains, for a manual recovery.
+
 Exit codes are the contract with the panel:
 
 | | |
@@ -240,6 +247,19 @@ signed manifest. That copy is what runs, never the installed one: a release
 replaces `mbrc-helper.exe` too, and a running image cannot overwrite itself. It
 runs elevated out of a user-writable directory, so checking it before *execution*
 - earlier than the check it then performs on the DLLs - is the boundary.
+
+The file is opened **denying write and delete sharing**, verified through that
+handle, and the handle is held open across `ShellExecuteExW`. Verifying by path
+and then launching by path would leave a window in which any process running as
+the user could replace the file after it verified and have its own binary run as
+administrator, on the prompt the user was expecting. Execution still works:
+Windows counts `FILE_EXECUTE` as read access when it checks sharing.
+
+A staged bundle that verifies but is **not newer than the running plugin is
+refused** (`NotAnUpgrade`). Every release is public and signed, so a signature
+proves a bundle is ours, not that it is the right one to install - without this,
+anyone able to write to the staging directory could roll the plugin back to an
+older release, signature and all, and undo whatever the newer one fixed.
 
 Elevation is requested with `ShellExecuteExW` and the `runas` verb, chosen by
 probing whether the plugins directory is writable (by writing, not by reading an

--- a/packages/mbrc-core/Cargo.toml
+++ b/packages/mbrc-core/Cargo.toml
@@ -65,6 +65,9 @@ mdns-sd = { version = "=0.21.0", default-features = false }
 windows-sys = { version = "=0.61.2", features = [
     "Win32_Foundation",
     "Win32_System_LibraryLoader",
+    # FILE_SHARE_READ: the staged helper is opened denying write and delete
+    # sharing so it cannot be swapped between verification and launch.
+    "Win32_Storage_FileSystem",
     # SHELLEXECUTEINFOW carries an HKEY field, so the struct lives behind the
     # registry feature even though nothing here touches the registry.
     "Win32_System_Registry",

--- a/packages/mbrc-core/src/ffi/types.rs
+++ b/packages/mbrc-core/src/ffi/types.rs
@@ -56,6 +56,11 @@ pub enum UpdateLaunch {
     VerifyFailed = 3,
     /// Something else went wrong; the detail is in the log.
     Failed = 4,
+    /// The staged bundle verified, but it is not newer than what is installed.
+    /// Every release is public and signed, so a signature does not by itself
+    /// make a bundle the right one to apply - this is what stops a stale one
+    /// being used to roll the plugin back.
+    NotAnUpgrade = 5,
 }
 
 /// Notifications forwarded from MusicBee via `Plugin.ReceiveNotification`.

--- a/packages/mbrc-core/src/lib.rs
+++ b/packages/mbrc-core/src/lib.rs
@@ -320,16 +320,22 @@ pub unsafe extern "C" fn mbrc_set_log_level(directive: *const c_char) -> c_int {
 /// Returns an [`UpdateLaunch`] value. `Launched` means the helper is up and
 /// waiting for MusicBee to exit - the caller is expected to shut MusicBee down
 /// next. `Cancelled` (the user declined elevation) is a normal outcome and
-/// leaves the staged update in place for a retry.
+/// leaves the staged update in place for a retry. `NotAnUpgrade` means the
+/// staged bundle verified but is not newer than the running plugin, which is a
+/// refusal rather than a failure: a valid signature does not make a stale
+/// release the right one to install.
 #[no_mangle]
 pub extern "C" fn mbrc_apply_staged_update() -> c_int {
-    ffi_guard("mbrc_apply_staged_update", || match state::storage_path() {
-        Some(storage) => updates::elevate::launch(&storage) as c_int,
-        None => {
-            tracing::error!("cannot apply an update before the core is initialized");
-            UpdateLaunch::Failed as c_int
-        }
-    })
+    ffi_guard(
+        "mbrc_apply_staged_update",
+        || match state::apply_staged_update() {
+            Some(outcome) => outcome as c_int,
+            None => {
+                tracing::error!("cannot apply an update before the core is initialized");
+                UpdateLaunch::Failed as c_int
+            }
+        },
+    )
 }
 
 /// Free a string previously returned to C# by the core. Null-safe. This is the

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -169,6 +169,30 @@ pub fn write_settings_bytes(bytes: &[u8]) -> Result<(), String> {
     std::fs::write(&path, pretty).map_err(|e| format!("write settings: {e}"))
 }
 
+/// Hand the staged update to the elevated helper.
+///
+/// The version the host reports is the one the staged bundle has to beat: a
+/// signature proves a bundle is ours, not that it is newer than what is running,
+/// and every release is public. `None` when the core is not initialized.
+pub fn apply_staged_update() -> Option<crate::ffi::types::UpdateLaunch> {
+    let core = {
+        let guard = lock();
+        guard.as_ref()?.core.clone()
+    };
+    let storage = core.config.storage_path.clone();
+    if storage.is_empty() {
+        return None;
+    }
+    // Falling back to the core's own version keeps a host that cannot answer
+    // from turning into an unconditional refusal; the two are stamped from the
+    // same `Directory.Build.props`.
+    let current = core.providers.plugin_version().unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "the host could not report its version; using the core's");
+        crate::updates::CORE_VERSION.to_owned()
+    });
+    Some(crate::updates::elevate::launch(&storage, &current))
+}
+
 /// Whether a core is currently initialized.
 ///
 /// For background work that outlives the call that started it: the C# callback

--- a/packages/mbrc-core/src/updates/elevate.rs
+++ b/packages/mbrc-core/src/updates/elevate.rs
@@ -3,17 +3,28 @@
 //! The panel presses a button; this decides whether elevation is needed, proves
 //! the helper it is about to run is the one the release signed, and launches it.
 //!
-//! Three things here are not arbitrary:
+//! Four things here are not arbitrary:
 //!
 //! - **Nothing is taken from the caller.** The plugins directory is where this
 //!   very DLL was loaded from, MusicBee is this process, and the pid is our own.
 //!   A panel that could name the directory to overwrite would be a panel worth
 //!   attacking; there is nothing to pass, so there is nothing to tamper with.
-//! - **The staged helper is verified before it is *executed*.** It runs elevated
-//!   out of a user-writable directory, so its signature check is the security
-//!   boundary, and it lands earlier than the check the helper does on the DLLs.
-//!   The installed helper cannot be used instead: a release replaces
-//!   `mbrc-helper.exe` too, and a running image cannot overwrite itself.
+//! - **The staged helper is verified before it is *executed*, and cannot be
+//!   swapped in between.** It runs elevated out of a user-writable directory, so
+//!   its signature check is the security boundary, and it lands earlier than the
+//!   check the helper performs on the DLLs. Verifying by path and then launching
+//!   by path would leave a window: any process running as this user could
+//!   replace the file after it verified and have *its* binary run as
+//!   administrator, on the prompt the user was expecting. So the file is opened
+//!   denying write and delete sharing, verified through that handle, and the
+//!   handle is held open across the launch. The installed helper cannot be used
+//!   instead: a release replaces `mbrc-helper.exe` too, and a running image
+//!   cannot overwrite itself.
+//! - **A staged bundle that is not newer is refused.** Every release is public
+//!   and legitimately signed, so a signature alone does not make a bundle the
+//!   right one to install: without this, anyone who can write to the staging
+//!   directory could roll the plugin back to an older release - with a valid
+//!   signature - and undo whatever the newer one fixed.
 //! - **Elevation is asked for now, not later.** `runas` prompts while the user is
 //!   still looking at the button they pressed. If the helper self-elevated after
 //!   MusicBee had exited, a declined prompt would leave a closed MusicBee, no UI,
@@ -36,7 +47,7 @@ const SIGNATURE_ASSET: &str = "manifest.json.minisig";
 /// Returns the outcome the panel reports; the detail goes to the log, because a
 /// UI that has to render every failure mode is a UI that renders none of them
 /// well.
-pub fn launch(storage_path: &str) -> UpdateLaunch {
+pub fn launch(storage_path: &str, current_version: &str) -> UpdateLaunch {
     let pending = match mbrc_release::read_pending(storage_path) {
         Ok(Some(pending)) => pending,
         Ok(None) => return UpdateLaunch::NothingStaged,
@@ -57,6 +68,17 @@ pub fn launch(storage_path: &str) -> UpdateLaunch {
         }
     };
 
+    // Signed, but is it *newer*? Every release is public and signed, so a stale
+    // bundle staged by someone else carries a perfectly good signature.
+    if !is_upgrade(&helper.version, current_version) {
+        tracing::error!(
+            staged = %helper.version,
+            installed = current_version,
+            "refusing to apply a staged update that is not newer than what is installed"
+        );
+        return UpdateLaunch::NotAnUpgrade;
+    }
+
     let target = match plugins_dir() {
         Some(dir) => dir,
         None => {
@@ -74,22 +96,64 @@ pub fn launch(storage_path: &str) -> UpdateLaunch {
 
     let elevate = !is_writable(&target);
     tracing::info!(
-        version = %pending.version,
-        helper = %helper.display(),
+        version = %helper.version,
+        helper = %helper.path.display(),
         target = %target.display(),
         elevate,
         "launching the update helper"
     );
 
-    spawn(&helper, &arguments(&staged, &target, &relaunch), elevate)
+    let outcome = spawn(
+        &helper.path,
+        &arguments(&staged, &target, &relaunch),
+        elevate,
+    );
+    // Explicit, so it is obvious that the handle is what has been holding the
+    // verified bytes in place all the way through the launch.
+    drop(helper);
+    outcome
+}
+
+/// Whether `staged` is newer than what is installed.
+///
+/// Unparseable on either side is not an upgrade: a version that cannot be
+/// compared cannot be shown to be newer, and this is the last gate before an
+/// elevated file swap.
+fn is_upgrade(staged: &str, installed: &str) -> bool {
+    match (
+        mbrc_release::version::parse(staged),
+        mbrc_release::version::parse(installed),
+    ) {
+        (Ok(staged), Ok(installed)) => staged > installed,
+        (staged, installed) => {
+            tracing::warn!(
+                staged_ok = staged.is_ok(),
+                installed_ok = installed.is_ok(),
+                "could not compare the staged and installed versions"
+            );
+            false
+        }
+    }
+}
+
+/// A staged helper that has verified, with the handle that keeps it that way.
+///
+/// Holding `_handle` open is what makes the verification mean anything at launch
+/// time: it denies write and delete sharing, so between the hash check and
+/// `ShellExecuteExW` the file cannot be rewritten, renamed or replaced.
+struct VerifiedHelper {
+    path: PathBuf,
+    version: String,
+    _handle: std::fs::File,
 }
 
 /// The staged helper, once the release signature says it is the right bytes.
 ///
 /// Verified from the *staged* manifest and signature, not from anything the core
 /// remembers about the download: the point is to check the file that is about to
-/// run as administrator, now, in the state it is in on disk.
-fn verified_helper(staged: &Path) -> Result<PathBuf, String> {
+/// run as administrator, now, in the state it is in on disk - and, via the
+/// handle, to keep that from changing before it does.
+fn verified_helper(staged: &Path) -> Result<VerifiedHelper, String> {
     let manifest_bytes =
         std::fs::read(staged.join(MANIFEST_ASSET)).map_err(|e| format!("{MANIFEST_ASSET}: {e}"))?;
     let signature = std::fs::read_to_string(staged.join(SIGNATURE_ASSET))
@@ -97,11 +161,41 @@ fn verified_helper(staged: &Path) -> Result<PathBuf, String> {
     let (manifest, key) =
         verify_manifest(&manifest_bytes, &signature).map_err(|e| e.to_string())?;
 
-    let helper = staged.join(HELPER_EXE);
-    let bytes = std::fs::read(&helper).map_err(|e| format!("{HELPER_EXE}: {e}"))?;
+    let path = staged.join(HELPER_EXE);
+    let mut handle = open_exclusive(&path).map_err(|e| format!("{HELPER_EXE}: {e}"))?;
+    let mut bytes = Vec::new();
+    std::io::Read::read_to_end(&mut handle, &mut bytes)
+        .map_err(|e| format!("{HELPER_EXE}: {e}"))?;
     verify_bundled_file(&manifest, HELPER_EXE, &bytes).map_err(|e| e.to_string())?;
     log_verified(&manifest, key);
-    Ok(helper)
+    Ok(VerifiedHelper {
+        path,
+        version: manifest.version,
+        _handle: handle,
+    })
+}
+
+/// Opens a file for reading while denying write and delete sharing.
+///
+/// Execution is still allowed: Windows counts `FILE_EXECUTE` as read access when
+/// it checks sharing, so the loader can map the image while this handle is open.
+/// What it cannot do is change underneath us.
+#[cfg(windows)]
+fn open_exclusive(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+
+    std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ)
+        .open(path)
+}
+
+/// No equivalent sharing model here; the module compiles for the Linux CI runner
+/// and its tests, not for a machine that has MusicBee on it.
+#[cfg(not(windows))]
+fn open_exclusive(path: &Path) -> std::io::Result<std::fs::File> {
+    std::fs::File::open(path)
 }
 
 fn log_verified(manifest: &Manifest, key: &str) {
@@ -275,7 +369,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         assert_eq!(
-            launch(&dir.to_string_lossy()),
+            launch(&dir.to_string_lossy(), "1.5.0.0"),
             UpdateLaunch::NothingStaged,
             "an empty storage directory means there is nothing to apply"
         );
@@ -299,7 +393,10 @@ mod tests {
         std::fs::write(staged.join(SIGNATURE_ASSET), "not a signature").unwrap();
         std::fs::write(staged.join(HELPER_EXE), b"not the helper").unwrap();
 
-        assert_eq!(launch(&dir.to_string_lossy()), UpdateLaunch::VerifyFailed);
+        assert_eq!(
+            launch(&dir.to_string_lossy(), "1.5.0.0"),
+            UpdateLaunch::VerifyFailed
+        );
     }
 
     #[test]
@@ -329,6 +426,25 @@ mod tests {
             line,
             "\"--target\" \"C:\\Program Files\\MusicBee\\Plugins\""
         );
+    }
+
+    #[test]
+    fn only_a_newer_bundle_is_an_upgrade() {
+        // The host reports a four-component .NET version; the staged manifest
+        // carries three. Both normalize before they are compared.
+        assert!(is_upgrade("1.6.0", "1.5.0.0"));
+        assert!(is_upgrade("1.5.1", "1.5.0.0"));
+        // The case this gate exists for: a real, signed, older release staged by
+        // someone who could write to the staging directory.
+        assert!(!is_upgrade("1.4.1", "1.5.0.0"));
+        assert!(!is_upgrade("1.5.0", "1.5.0.0"));
+        // A prerelease sits below the release it precedes, so being offered
+        // 1.6.0-rc.1 while running 1.6.0 is not an upgrade either.
+        assert!(!is_upgrade("1.6.0-rc.1", "1.6.0.0"));
+        assert!(is_upgrade("1.6.0-rc.1", "1.5.0.0"));
+        // Unparseable on either side cannot be shown to be newer.
+        assert!(!is_upgrade("not-a-version", "1.5.0.0"));
+        assert!(!is_upgrade("1.6.0", ""));
     }
 
     #[test]

--- a/packages/mbrc-helper/src/update.rs
+++ b/packages/mbrc-helper/src/update.rs
@@ -173,10 +173,10 @@ pub fn apply_with(
             Ok(Applied {
                 version: bundle.manifest.version,
                 files: bundle.files.iter().map(|(n, _)| n.clone()).collect(),
-                backup,
+                backup: backup.dir,
             })
         }
-        Err(cause) => Err(restore(backup.as_deref(), &plan.target, &bundle, cause)),
+        Err(cause) => Err(restore(&backup, &plan.target, cause)),
     }
 }
 
@@ -226,40 +226,59 @@ fn verify_staged(staged: &Path, keys: &'static [TrustedKey]) -> Result<Bundle> {
     Ok(Bundle { manifest, files })
 }
 
-/// Copies the files about to be replaced into `backup/<version>/`.
+/// The files this apply is replacing: the bytes, and where a copy of them was
+/// also written for a manual recovery.
+struct Backup {
+    /// `backup/<version>/`, or `None` when there was nothing to replace.
+    dir: Option<PathBuf>,
+    /// What was installed before, held in memory. **The restore writes from
+    /// here, not from `dir`.** That directory lives under the user's profile,
+    /// so any unelevated process can rewrite it between the backup and the
+    /// restore; copying it back would turn that write into an elevated one -
+    /// the same reason the payload is verified in memory rather than re-read.
+    files: Vec<(String, Vec<u8>)>,
+}
+
+/// Reads the files about to be replaced, and keeps a copy in `backup/<version>/`.
 ///
 /// Named for the version being applied - "what installing 1.6.0 replaced" -
 /// because the version being replaced is not recorded anywhere the helper can
-/// read. Returns `None` when there was nothing to back up, which is a fresh
-/// install rather than an error.
-fn back_up(plan: &Plan, bundle: &Bundle) -> Result<Option<PathBuf>> {
+/// read. An empty result is a fresh install rather than an error.
+fn back_up(plan: &Plan, bundle: &Bundle) -> Result<Backup> {
     let root = backup_root(&plan.staged)?.join(&bundle.manifest.version);
     if root.exists() {
         std::fs::remove_dir_all(&root).map_err(|e| failed(&root, e))?;
     }
 
-    let mut saved = 0usize;
+    let mut files = Vec::new();
     for (name, _) in &bundle.files {
         let current = plan.target.join(name);
         if !current.exists() {
             continue;
         }
         refuse_reparse_point(&current)?;
-        if saved == 0 {
+        let bytes = read(&current)?;
+        if files.is_empty() {
             std::fs::create_dir_all(&root).map_err(|e| failed(&root, e))?;
         }
-        std::fs::copy(&current, root.join(name)).map_err(|e| failed(&current, e))?;
-        saved += 1;
+        // Written from the bytes just read, so the on-disk copy and the one the
+        // restore would use cannot disagree.
+        std::fs::write(root.join(name), &bytes).map_err(|e| failed(&current, e))?;
+        files.push((name.clone(), bytes));
     }
 
-    if saved == 0 {
-        return Ok(None);
+    if files.is_empty() {
+        return Ok(Backup { dir: None, files });
     }
     println!(
-        "mbrc-helper: backed up {saved} file(s) to {}",
+        "mbrc-helper: backed up {} file(s) to {}",
+        files.len(),
         root.display()
     );
-    Ok(Some(root))
+    Ok(Backup {
+        dir: Some(root),
+        files,
+    })
 }
 
 /// Writes the verified bytes into the plugins directory.
@@ -278,26 +297,31 @@ fn write_all(plan: &Plan, bundle: &Bundle) -> std::result::Result<(), String> {
 }
 
 /// Puts the previous files back after a failed swap.
-fn restore(backup: Option<&Path>, target: &Path, bundle: &Bundle, cause: String) -> Error {
-    let Some(backup) = backup else {
+///
+/// Written from the bytes read during the backup, never re-read from the backup
+/// directory: that directory is under the user's profile and an unelevated
+/// process can rewrite it while this one is running, which would make the
+/// restore an elevated write of somebody else's bytes.
+fn restore(backup: &Backup, target: &Path, cause: String) -> Error {
+    if backup.files.is_empty() {
         // Nothing was replaced, so there is nothing to put back: this was a
         // fresh install that failed part way.
         return Error::RolledBack { cause };
-    };
+    }
 
     let mut failures = Vec::new();
-    for (name, _) in &bundle.files {
-        let from = backup.join(name);
-        if !from.exists() {
+    for (name, bytes) in &backup.files {
+        let to = target.join(name);
+        if refuse_reparse_point(&to).is_err() {
+            failures.push(format!("{name}: became a link"));
             continue;
         }
-        let to = target.join(name);
-        if let Err(e) = std::fs::copy(&from, &to) {
+        if let Err(e) = std::fs::write(&to, bytes) {
             // The file that could not be *written* is usually the one that
             // cannot be written back either - read-only, locked, out of space.
             // That is not a failed restore if the installed file was never
             // replaced: it is already what the backup holds.
-            if already_restored(&from, &to) {
+            if already_restored(bytes, &to) {
                 continue;
             }
             failures.push(format!("{name}: {e}"));
@@ -319,11 +343,8 @@ fn restore(backup: Option<&Path>, target: &Path, bundle: &Bundle, cause: String)
 /// Compared by content rather than assumed from the write having failed: the
 /// point is to distinguish "never replaced" from "replaced and now unrecoverable",
 /// and only the bytes say which.
-fn already_restored(backup: &Path, installed: &Path) -> bool {
-    match (std::fs::read(backup), std::fs::read(installed)) {
-        (Ok(a), Ok(b)) => a == b,
-        _ => false,
-    }
+fn already_restored(backup: &[u8], installed: &Path) -> bool {
+    matches!(std::fs::read(installed), Ok(current) if current == backup)
 }
 
 /// Keeps the newest backup and removes the rest. One is enough for a manual
@@ -730,9 +751,37 @@ mod tests {
         let blocked = fixture.target.join("mb_remote.dll");
         set_read_only(&blocked, true);
 
-        let err = restore(backup.as_deref(), &plan.target, &bundle, "disk full".into());
+        let err = restore(&backup, &plan.target, "disk full".into());
         set_read_only(&blocked, false);
         assert!(matches!(err, Error::RollbackFailed { .. }), "{err}");
+    }
+
+    #[test]
+    fn the_restore_ignores_a_rewritten_backup_directory() {
+        // The backup directory is under the user's profile, so an unelevated
+        // process can rewrite it while the elevated apply is running. If the
+        // restore read from there, that write would land in the plugins
+        // directory as administrator. It restores from the bytes it read, so
+        // this rewrite is inert.
+        let fixture = Fixture::new("backup-tampered").with_installed(b"old");
+        let plan = fixture.plan();
+        let bundle = verify_staged(&plan.staged, TEST_KEYS).unwrap();
+        let backup = back_up(&plan, &bundle).unwrap();
+
+        let dir = backup.dir.clone().expect("something was replaced");
+        for (name, _) in PAYLOAD {
+            std::fs::write(dir.join(name), b"attacker bytes").unwrap();
+        }
+
+        let err = restore(&backup, &plan.target, "disk full".into());
+        assert!(matches!(err, Error::RolledBack { .. }), "{err}");
+        for (name, _) in PAYLOAD {
+            assert_eq!(
+                fixture.installed(name),
+                b"old",
+                "{name} was restored from the tampered directory"
+            );
+        }
     }
 
     #[test]

--- a/packages/mbrc-release/src/verify.rs
+++ b/packages/mbrc-release/src/verify.rs
@@ -75,18 +75,34 @@ pub fn verify_signature_with(
     let signature =
         Signature::decode(signature).map_err(|e| UpdateError::MalformedSignature(e.to_string()))?;
 
+    // A key that will not parse is skipped, not fatal. One corrupt entry in the
+    // compiled-in list would otherwise disable verification against every other
+    // key - failing closed, but failing *completely*, and the whole point of a
+    // list is that it survives losing one of them. If none parse there is no
+    // trust list to speak of, so the first failure is reported.
+    let mut malformed: Option<UpdateError> = None;
+    let mut usable = 0usize;
     for key in keys {
-        let public_key =
-            PublicKey::from_base64(key.base64).map_err(|e| UpdateError::MalformedKey {
-                name: key.name.to_owned(),
-                reason: e.to_string(),
-            })?;
+        let public_key = match PublicKey::from_base64(key.base64) {
+            Ok(public_key) => public_key,
+            Err(e) => {
+                malformed.get_or_insert(UpdateError::MalformedKey {
+                    name: key.name.to_owned(),
+                    reason: e.to_string(),
+                });
+                continue;
+            }
+        };
+        usable += 1;
 
         if public_key.verify(bytes, &signature, false).is_ok() {
             return Ok(key.name);
         }
     }
 
+    if usable == 0 {
+        return Err(malformed.unwrap_or(UpdateError::NoTrustedKeys));
+    }
     Err(UpdateError::UntrustedSignature)
 }
 

--- a/packages/mbrc-release/tests/verify_tests.rs
+++ b/packages/mbrc-release/tests/verify_tests.rs
@@ -105,6 +105,39 @@ fn bundled_file_must_be_in_the_allowlist() {
     assert!(err.to_string().contains("not listed"), "{err}");
 }
 
+#[test]
+fn one_unusable_key_does_not_disable_the_others() {
+    // A corrupt entry in the compiled-in list must not take the working keys
+    // down with it: that would fail closed, but it would fail *completely*, and
+    // a trust list exists precisely so that losing one member is survivable.
+    const MIXED: &[TrustedKey] = &[
+        TrustedKey {
+            name: "corrupt",
+            base64: "this is not a minisign key",
+        },
+        TrustedKey {
+            name: "test",
+            base64: "RWT+ztjSHP1aBowOy75aVsw0jf2Vn6MMbzuTIAPRaN5EWVPjPU9fjwAj",
+        },
+    ];
+
+    assert_eq!(
+        verify_signature_with(GOLDEN.as_bytes(), GOLDEN_SIG, MIXED).unwrap(),
+        "test"
+    );
+
+    // With nothing usable left, the malformed key is what gets reported - the
+    // caller should hear "your trust list is broken", not "bad signature".
+    const ONLY_CORRUPT: &[TrustedKey] = &[TrustedKey {
+        name: "corrupt",
+        base64: "this is not a minisign key",
+    }];
+    let err = verify_signature_with(GOLDEN.as_bytes(), GOLDEN_SIG, ONLY_CORRUPT)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("malformed"), "{err}");
+}
+
 /// Guards the real trust list itself: a mangled or truncated `.pub` file should
 /// fail here, at test time, not during a release.
 #[test]

--- a/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridge.Generated.cs
@@ -148,7 +148,10 @@ namespace MusicBeePlugin.Ffi.Generated
         ///  Returns an [`UpdateLaunch`] value. `Launched` means the helper is up and
         ///  waiting for MusicBee to exit - the caller is expected to shut MusicBee down
         ///  next. `Cancelled` (the user declined elevation) is a normal outcome and
-        ///  leaves the staged update in place for a retry.
+        ///  leaves the staged update in place for a retry. `NotAnUpgrade` means the
+        ///  staged bundle verified but is not newer than the running plugin, which is a
+        ///  refusal rather than a failure: a valid signature does not make a stale
+        ///  release the right one to install.
         /// </summary>
         [DllImport(__DllName, EntryPoint = "mbrc_apply_staged_update", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         internal static extern int mbrc_apply_staged_update();

--- a/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
+++ b/packages/plugin/Ffi/Generated/NativeBridgeEnums.Generated.cs
@@ -26,6 +26,7 @@ namespace MusicBeePlugin.Ffi.Generated
         Cancelled = 2,
         VerifyFailed = 3,
         Failed = 4,
+        NotAnUpgrade = 5,
     }
 
     public enum NotificationType

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -966,6 +966,14 @@ namespace MusicBeePlugin.Settings
                         "Installation needs permission to change the plugin files. "
                         + "The download is still there - press Install and restart to try again.";
                     break;
+                case Ffi.Generated.UpdateLaunch.NotAnUpgrade:
+                    // The bundle verified but is not newer. Every release is
+                    // public and signed, so this is what a stale one staged by
+                    // something other than a check looks like.
+                    _updateStatus.Text =
+                        "The downloaded update is not newer than the installed version, "
+                        + "so it was not applied. Check again for a newer release.";
+                    break;
                 case Ffi.Generated.UpdateLaunch.VerifyFailed:
                     // The one outcome worth interrupting for: the staged bundle no
                     // longer matches what the release signed.


### PR DESCRIPTION
A security review of the update mechanism (verification, staging, the elevated
helper, the transport) turned up three things worth fixing. The design held up
otherwise - verification happens before parsing, and the payload is verified in
memory and written from that same buffer - so these are the places where those
rules were not being followed.

## 1. The rollback wrote unverified bytes into Program Files, elevated

`back_up` copied the files it was about to replace into `<storage>/backup/<version>/`,
which lives under the user's profile and is writable by **any unelevated process
running as that user**. If `write_all` then failed part way, `restore` copied
those files straight back into the plugins directory - no hash, no manifest
lookup.

The primitive: watch for the backup directory to appear, overwrite `mb_remote.dll`
in it, cause one of the three writes to fail, and the elevated helper puts
attacker-controlled bytes into `C:\Program Files\...\Plugins`, which MusicBee
loads at next start. Forcing the failure is the awkward part (Program Files is not
attacker-writable, so it means disk exhaustion or a locked file) but the shape is
"elevated write of unverified bytes" and the fix is nearly free.

`back_up` already had to read each file to copy it, so it now keeps those bytes
and `restore` writes from memory. The on-disk copy is still written, for a manual
recovery. This is the rule `verify_staged`/`write_all` already followed, applied to
the path that had been missed.

Covered by a new test that rewrites the backup directory behind the helper's back
and asserts the restore ignores it.

## 2. The staged helper could be swapped between verification and launch

`verified_helper` hashed `<storage>/updates/<version>/mbrc-helper.exe` against the
signed manifest and returned its **path**; `spawn` then handed that path to
`ShellExecuteExW` with `runas`. Between those two moments the file could be
replaced by any process running as the user - the staging directory is
user-writable by design.

The result would be the attacker's binary running elevated, on a UAC prompt the
user had just asked for and was expecting to see. The module's own comment
promised the opposite ("the file that is about to run as administrator, now, in
the state it is in on disk"), which is exactly the guarantee that did not hold.

The file is now opened with `share_mode(FILE_SHARE_READ)` - denying write **and**
delete sharing - verified through that handle, and the handle is held open across
the launch, so the contents cannot be rewritten and the name cannot be replaced or
renamed. Execution is unaffected: `IoCheckShareAccess` counts `FILE_EXECUTE` as
read access, so the loader can still map the image.

**This is the one change here that cannot be unit-tested and has never run.** It
needs the `v1.5.0-rc.1` rehearsal to prove the launch still works with the handle
held. If it were to fail it would fail visibly and safely (a sharing violation at
launch, nothing applied), but it needs to be seen.

## 3. Nothing refused a downgrade

`check` only ever offers a newer version, but the apply took whatever was staged.
Every release is public and signed, so a stale bundle is a perfectly valid bundle:
writing an old release into the staging directory rolls the plugin back the next
time the user presses Install - signature and all - undoing whatever the newer
version fixed.

`mbrc_apply_staged_update` now asks the host for its version and refuses a staged
bundle that is not strictly newer, as its own outcome (`NotAnUpgrade` = 5) rather
than a failure: the bundle is intact, it is simply not the right one to apply. The
panel says so. Version comparison goes through the same `version::parse` the check
uses, so the four-component .NET string and the three-component manifest version
normalise the same way, and a prerelease still sorts below its release.

`UpdateLaunch` gains a variant; that enum is generated, additive, and never
renumbered, so `MBRC_ABI_VERSION` stays at 1.

## Also

A malformed key in the compiled-in trust list no longer disables verification
against the others. It failed closed, but it failed *completely*, and a list
exists precisely so that losing one member is survivable. With nothing usable
left, the malformed key is what gets reported - "your trust list is broken" rather
than "bad signature".

## Considered and left alone

- **`update_state.json` is user-writable**, so a local attacker can set
  `skipped_version` or a bogus `etag` to suppress checks. Accepted: someone with
  that access has better options.
- **The helper writes wherever `--target` says**, gated only by the signature on
  contents. That is deliberate (elevation can run under a different admin profile,
  so a derived path would be wrong) and costs a UAC consent to abuse. Worth
  revisiting only if the helper ever gains an auto-elevating manifest, which would
  turn it into a free arbitrary-write primitive.
- **The 64 MiB body cap** is right, but it is a silent ceiling on bundle size - a
  release that outgrows it fails as "the download failed".

## Testing

Workspace tests (including the new backup-tampering and version-comparison cases)
and clippy green; C# builds and `dotnet format` clean.
