### PR TITLE
fix: make a prerelease build updatable, and stop failing silently on old MusicBee

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,14 @@ jobs:
       - name: build with strict analysis
         env:
           VERSION: ${{ steps.version.outputs.VERSION }}
+          # The Rust core and helper stamp themselves from this; without it
+          # mbrc-buildinfo falls back to VersionPrefix in Directory.Build.props,
+          # so every prerelease build would call itself the final version - in
+          # its log lines, in the mDNS TXT record, and in the update check's
+          # fallback when the host cannot report its own version. MSBuild drives
+          # the Rust build through the csproj target, so the environment reaches
+          # it from here.
+          MBRC_VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           echo "🔍 Building with strict static analysis (warnings as errors)..."
           msbuild MBRC.sln /p:Configuration="Release" /p:MSBuildCI="true" /p:Version=$env:VERSION /m /v:M /fl /nr:false

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 * [About the Project](#about-the-project)
   * [Built With](#built-with)
   * [Project Structure](#project-structure)
+  * [Documentation](#documentation)
 * [Installation](#installation)
 * [Getting Started](#getting-started)
   * [Prerequisites](#prerequisites)
@@ -66,6 +67,7 @@ plugin API.
 * [MessagePack-CSharp](https://github.com/MessagePack-CSharp/MessagePack-CSharp) - FFI DTO serialization
 * [Costura.Fody](https://github.com/Fody/Costura) - embeds the managed dependencies into `mb_remote.dll`
 * [minisign-verify](https://github.com/jedisct1/rust-minisign-verify) - release manifest signatures
+* [mdns-sd](https://github.com/keepsimple1/mdns-sd) - DNS-SD advertisement, alongside the custom discovery
 
 ### Project Structure
 
@@ -78,6 +80,7 @@ mbrc-plugin/
 │   ├── mbrc-capture/   # Capture and fixture tooling
 │   ├── mbrc-release/   # Release manifest parsing, signature verification
 │   ├── mbrc-helper/    # Elevated helper exe: firewall rule, staged update apply
+│   ├── mbrc-buildinfo/ # Stamps the product version into the Rust binaries
 │   └── plugin/         # MusicBee plugin (mb_remote.dll): entry point, API callbacks
 ├── tests/
 │   ├── csharp/         # xUnit suite for the C# shim
@@ -91,6 +94,13 @@ The C# core was folded into the plugin project, so the managed side builds as a
 single `mb_remote.dll` with its NuGet dependencies embedded by Costura. The
 native `mbrc_core.dll` and `mbrc-helper.exe` are not embedded and ship
 side-by-side with it.
+
+### Documentation
+
+* [`docs/protocol.md`](docs/protocol.md) - the wire protocol: commands, events,
+  and both discovery mechanisms (custom UDP multicast and mDNS / DNS-SD)
+* [`docs/updates.md`](docs/updates.md) - the update mechanism end to end: the
+  signed manifest, the channels, staging, and the elevated helper
 
 ## Installation
 
@@ -116,7 +126,9 @@ Use this method for the Microsoft Store version of MusicBee or if you prefer man
    - Store version: `%LOCALAPPDATA%\Packages\...\LocalCache\Roaming\MusicBee\Plugins\`
 
    The plugin loads the native core at startup, so they must sit side by side.
-4. Optionally copy `mbrc-helper.exe` if you want the Windows Firewall rule added for you
+4. Copy `mbrc-helper.exe` as well. It is optional, but it is what adds the Windows
+   Firewall rule and what installs updates the plugin downloads - without it,
+   "Install and restart" in the settings has nothing to run
 5. Restart MusicBee
 
 ### Verify Installation
@@ -131,6 +143,16 @@ As a developer there are a few steps you need to follow to get started:
 
 * [Visual Studio 2026 Community](https://visualstudio.microsoft.com/vs/community/) (2022 also supported)
 * [.NET Framework 4.8](https://dotnet.microsoft.com/download/dotnet-framework/net48) SDK
+* [Rust](https://rustup.rs/) with the 32-bit Windows target - the core and the
+  helper are Rust, and the plugin is x86, so they must be built for
+  `i686-pc-windows-msvc`:
+
+  ```bash
+  rustup target add i686-pc-windows-msvc
+  ```
+
+  The toolchain version itself is pinned by `rust-toolchain.toml`, so rustup
+  fetches the right one on the first build.
 * [MusicBee](http://getmusicbee.com/) installed (for testing)
 
 After getting the basic environment setup you just need to clone the project from command line:
@@ -173,8 +195,11 @@ dotnet build -c Release
 
 **Build Script (Windows / PowerShell):**
 ```powershell
-.\build-msbuild.ps1                       # Release build (default)
-.\build-msbuild.ps1 -Configuration Debug  # Debug build
+.\build.ps1                       # both halves, Release
+.\build.ps1 -Configuration Debug  # both halves, Debug
+.\build.ps1 -Rust                 # just the Rust core + helper
+.\build.ps1 -Plugin               # just the C# plugin
+.\build.ps1 -Clean                # remove build output first
 ```
 
 The build process:
@@ -182,10 +207,13 @@ The build process:
 2. Compiles the plugin project into `mb_remote.dll`, with Costura embedding the
    managed NuGet dependencies
 3. In Debug mode, copies `mb_remote.dll`, `mbrc_core.dll` and `mbrc-helper.exe`
-   to MusicBee's Plugins folder
+   to MusicBee's Plugins folder for a live test install; Release only stages them
+   under `build\bin\plugin\`
 
-Note that `build-msbuild.ps1` builds only the C# solution. Use `.\build.ps1` for
-a full build of both halves.
+`build-msbuild.ps1` is the C#-solution entry point, but it is not Rust-free: the
+plugin project has an MSBuild target that invokes `build.ps1 -Rust`, so the core
+and helper are built either way. That target is also why `dotnet build` and
+Visual Studio produce a complete set of binaries.
 
 ## Testing
 
@@ -236,10 +264,16 @@ The version is centralized in `Directory.Build.props`:
 ```
 
 Every shipped component inherits this version automatically: the C# assemblies
-through MSBuild, and `mbrc-helper.exe` through its `build.rs`, which reads the
-same `<VersionPrefix>` at compile time. Bumping it here is the only edit needed.
-CI may override the helper's stamp via the `MBRC_VERSION` environment variable so
-nightlies carry their full suffixed version.
+through MSBuild, and `mbrc_core.dll` + `mbrc-helper.exe` through `mbrc-buildinfo`,
+which reads the same `<VersionPrefix>` at compile time. Bumping it here is the
+only edit needed. CI overrides the Rust stamp via the `MBRC_VERSION` environment
+variable, so a build from a tag carries the tag's full version rather than the
+bare prefix.
+
+The version the plugin reports to the updater is the *informational* version, not
+`AssemblyVersion` - MSBuild strips prerelease suffixes from the latter, which
+would make `1.5.0-beta.1` indistinguishable from `1.5.0` and leave a prerelease
+unable to update itself.
 
 ### Creating a Release
 
@@ -263,7 +297,27 @@ The CI pipeline will automatically:
 - Create the ZIP archive (`musicbee_remote_1.5.0.zip`)
 - Generate SHA512 checksums
 - Create build provenance attestations
+- Emit and sign `manifest.json`, which is what the in-plugin updater verifies
 - Publish a GitHub Release with all artifacts
+
+### Prereleases
+
+A tag with a prerelease suffix routes itself - no separate workflow and no extra
+flags:
+
+```bash
+git tag v1.5.0-beta.1
+git push origin v1.5.0-beta.1
+```
+
+It is packaged, attested and signed exactly like a stable release; only two
+things differ. The manifest records `channel: testing` instead of `stable`, and
+the GitHub release is marked as a pre-release, which keeps it out of
+`releases/latest` - the endpoint the stable update channel follows. Users on the
+`testing` channel find it because that channel lists releases instead.
+
+See [`docs/updates.md`](docs/updates.md) for the channels, how to switch between
+them, and what the updater verifies before it installs anything.
 
 ### Development Builds
 

--- a/installer/README.txt
+++ b/installer/README.txt
@@ -9,8 +9,11 @@ Usually this is: C:\Program Files (x86)\MusicBee\Plugins\
 
 mb_remote.dll and mbrc_core.dll are both required: the plugin loads the native
 core at startup, and they must sit side by side in the same folder.
-The mbrc-helper.exe is optional and is used to add the Windows Firewall rule for
-the listening port.
+
+mbrc-helper.exe is optional but recommended. It is the elevated helper, used for
+two things: adding the Windows Firewall rule for the listening port, and
+installing updates the plugin downloads. Without it, "Install and restart" in the
+plugin's settings has nothing to run and updates have to be installed by hand.
 
 For Microsoft Store version of MusicBee:
 Go to MusicBee -> Edit -> Preferences -> Plugins and use the "Add Plugin" button
@@ -20,10 +23,17 @@ to install directly from the zip file.
 UNINSTALLATION
 --------------
 
-Delete mb_remote.dll from the Plugins folder.
+Close MusicBee, then delete all three files from the Plugins folder:
+
+    mb_remote.dll
+    mbrc_core.dll
+    mbrc-helper.exe
+
+Deleting only mb_remote.dll leaves the native core behind.
 
 The plugin stores its data under %APPDATA%\MusicBee\mb_remote\
-This folder can be safely deleted after uninstallation.
+This folder can be safely deleted after uninstallation. It holds the settings,
+the log, the library and cover caches, and any downloaded update.
 
 
 REQUIREMENTS

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -33,7 +33,7 @@ namespace MusicBeePlugin.Host
         private readonly IPluginLogger _logger;
         private bool _disposed;
 
-        public PluginHost(Plugin.MusicBeeApiInterface api, string storagePath, Version version)
+        public PluginHost(Plugin.MusicBeeApiInterface api, string storagePath, string version)
         {
             // All C# logs route through the Rust core's logger (one log file).
             // Pre-init logs fall back to mbrc-bootstrap.log in the same storage
@@ -52,7 +52,11 @@ namespace MusicBeePlugin.Host
             // Settings are Rust-owned; C# caches only the few the host reads
             // (search source, version, storage path), refreshed from the core
             // after init. The core migrates settings.xml and owns the JSON store.
-            var settings = new UserSettingsService { CurrentVersion = version.ToString() };
+            // The product version, prerelease suffix and all - not
+            // AssemblyVersion, which drops it. This is what the update check
+            // compares against, so a beta reporting the final version would
+            // never be offered anything (see Plugin.ProductVersion).
+            var settings = new UserSettingsService { CurrentVersion = version };
             settings.SetStoragePath(storagePath);
             _userSettings = settings;
 

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -123,7 +123,10 @@ namespace MusicBeePlugin
                 _about.ConfigurationPanelHeight = 120;
 
                 if (_api.ApiRevision < MinApiRevision)
+                {
+                    ReportUnsupportedHost(_api.ApiRevision);
                     return _about;
+                }
 
                 InitializeHost();
 
@@ -195,6 +198,17 @@ namespace MusicBeePlugin
         /// </summary>
         private void LogToFallback(string context, Exception ex)
         {
+            LogToFallback(context, ex.ToString());
+        }
+
+        /// <summary>
+        ///     As <see cref="LogToFallback(string, Exception)" />, for a condition that
+        ///     is not an exception. The core's own log does not exist yet at this
+        ///     point - it is created by the host - so this file is the only place an
+        ///     early refusal can be recorded.
+        /// </summary>
+        private void LogToFallback(string context, string detail)
+        {
             try
             {
                 var fallbackPath = Path.Combine(
@@ -203,12 +217,35 @@ namespace MusicBeePlugin
                     "initialization_error.log");
                 Directory.CreateDirectory(Path.GetDirectoryName(fallbackPath));
                 File.AppendAllText(fallbackPath,
-                    $"[{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}] {context}: {ex}\n");
+                    $"[{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.ffffffZ}] {context}: {detail}\n");
             }
             catch
             {
                 // If logging fails, continue silently to prevent MusicBee crash.
             }
+        }
+
+        /// <summary>
+        ///     Explains a MusicBee too old to run this plugin, in the two places
+        ///     someone will actually look.
+        /// </summary>
+        /// <remarks>
+        ///     Without this the refusal is completely silent: the plugin still appears
+        ///     in MusicBee's plugin list because <c>_about</c> is populated, but no
+        ///     server starts, Configure does nothing (there is no host to configure),
+        ///     and no log is written anywhere - the core's log does not exist because
+        ///     the host was never created. That is the hardest possible support case,
+        ///     so the description carries the reason to where the user is already
+        ///     looking, and the fallback file carries it to where a bug report can
+        ///     find it.
+        /// </remarks>
+        private void ReportUnsupportedHost(short apiRevision)
+        {
+            var reason =
+                $"Disabled: needs MusicBee API revision {MinApiRevision} or newer, but this MusicBee reports {apiRevision}. Update MusicBee from https://getmusicbee.com";
+
+            _about.Description = reason;
+            LogToFallback("Unsupported MusicBee version", reason);
         }
 
         /// <summary>

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -34,6 +34,53 @@ namespace MusicBeePlugin
         private string _version;
 
         /// <summary>
+        ///     The version this build actually is, prerelease suffix included.
+        /// </summary>
+        /// <remarks>
+        ///     <para>
+        ///         Not <c>AssemblyVersion</c>: MSBuild strips the suffix from it, so a
+        ///         <c>1.5.0-beta.1</c> build reports <c>1.5.0.0</c> - identical to the
+        ///         final release as far as the updater's comparison is concerned. A
+        ///         beta would then never be offered anything, including the release it
+        ///         is a beta of, which defeats the point of shipping one.
+        ///         <c>AssemblyInformationalVersion</c> keeps the whole string.
+        ///     </para>
+        ///     <para>
+        ///         Build metadata (<c>+&lt;sha&gt;</c>, which the SDK appends when
+        ///         source revision is included) is cut: semver ignores it in
+        ///         comparisons, and it is noise in the panel's footer.
+        ///     </para>
+        ///     <para>
+        ///         This does not reach the V4 wire. <c>pluginversion</c> there is
+        ///         pinned to 1.4.1.0 by the protocol layer, because the iOS client
+        ///         changes its behaviour based on it.
+        ///     </para>
+        /// </remarks>
+        private static string ProductVersion(Version assemblyVersion)
+        {
+            try
+            {
+                var informational = Assembly
+                    .GetExecutingAssembly()
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+                    ?.InformationalVersion;
+
+                if (!string.IsNullOrWhiteSpace(informational))
+                {
+                    var plus = informational.IndexOf('+');
+                    return plus >= 0 ? informational.Substring(0, plus) : informational;
+                }
+            }
+            catch (Exception)
+            {
+                // Fall through to the assembly version below; a plugin that cannot
+                // read its own metadata should still load.
+            }
+
+            return assemblyVersion.ToString();
+        }
+
+        /// <summary>
         ///     This function initialized the Plugin.
         /// </summary>
         /// <param name="apiInterfacePtr"></param>
@@ -50,7 +97,7 @@ namespace MusicBeePlugin
                 _api.Initialise(apiInterfacePtr);
 
                 var version = Assembly.GetExecutingAssembly().GetName().Version;
-                _version = version.ToString();
+                _version = ProductVersion(version);
 
                 _about.PluginInfoVersion = PluginInfoVersion;
                 _about.Name = "MusicBee Remote: Plugin";
@@ -78,7 +125,7 @@ namespace MusicBeePlugin
                 if (_api.ApiRevision < MinApiRevision)
                     return _about;
 
-                InitializeHost(version);
+                InitializeHost();
 
                 // A Tools menu entry opens the same settings dialog as the Configure
                 // button, matching the classic plugin's layout.
@@ -123,12 +170,11 @@ namespace MusicBeePlugin
         ///     catch-all so a startup failure leaves the plugin degraded (remote
         ///     off) rather than crashing MusicBee.
         /// </summary>
-        /// <param name="version">The plugin version from assembly.</param>
-        private void InitializeHost(Version version)
+        private void InitializeHost()
         {
             try
             {
-                _host = new PluginHost(_api, _api.Setting_GetPersistentStoragePath(), version);
+                _host = new PluginHost(_api, _api.Setting_GetPersistentStoragePath(), _version);
                 _host.Start();
             }
             catch (Exception ex)


### PR DESCRIPTION
Everything found while answering "what remains before we can cut `v1.5.0-beta.1`".
Three commits, each independent.

## 1. A prerelease could never update itself

MSBuild strips the prerelease suffix from `AssemblyVersion`, and that is what the
plugin reported over FFI. Verified on the built DLL:

```
FileVersion:    1.5.0.0                    <- what we reported
ProductVersion: 1.5.0-beta.1+ac4610b9...   <- what it actually is
```

So the updater compares:

| | |
|---|---|
| installed `1.5.0.0` | normalises to `1.5.0` |
| offered `1.5.0` (the final) | not newer -> **"up to date"** |
| offered `1.5.0-beta.2` | sorts *below* `1.5.0` -> also refused |

A beta would sit there forever, including when the release it is a beta of
shipped - and since #166 the `NotAnUpgrade` gate refuses a hand-staged bundle for
the same reason, so there was no way around it either. That would have made the
beta useless for the one thing it exists to prove.

Now the plugin reads `AssemblyInformationalVersion`, which keeps the whole
string, and cuts the `+<sha>` build metadata (semver ignores it when comparing;
it is noise in the panel footer). It reaches the updater through `PluginHost`,
which takes the product version as a string rather than a `System.Version` it
would only stringify back into `1.5.0.0`.

**This does not touch the V4 wire.** `pluginversion` there is pinned to `1.4.1.0`
by the protocol layer because the iOS client branches on it; the FFI-reported
version feeds only the update check and the panel label.

CI now also passes `MBRC_VERSION` to the build, so `mbrc_core.dll` and
`mbrc-helper.exe` stamp themselves with the real version instead of falling back
to `VersionPrefix`. Without it every prerelease build calls itself the final
version - in its log lines, in the mDNS TXT record, and in the update check's
fallback when the host cannot report its own version.

## 2. A MusicBee too old to run the plugin failed silently

`Initialise` returned the populated `_about` and did nothing else. No server, no
message, no log: the core's log does not exist at that point because the host was
never created, and `initialization_error.log` is only written from the `catch`,
which nothing threw into. The plugin still appears in MusicBee's plugin list, so
it looks installed and fine - and clicking **Configure** does nothing either,
because `Configure` returns false without a host.

That is the hardest possible support case: someone who sees the plugin listed,
finds no server, and has nothing to send anyone. The reason now goes to the two
places people actually look - the description MusicBee renders in the plugin row,
and the fallback log file - naming both the revision required and the one this
MusicBee reports.

**Left open deliberately.** The installer gates on MusicBee build 6500 while the
code gates on API revision 53, and those are different units. Revision 53 is not a
requirement this project chose: it is the constant MusicBee's own plugin template
ships (DiscordBee's copy of `MusicBeeInterface.cs` is byte-identical on this
point), and the template's mapping lumps everything above revision 48 into
"v3.1". So 3.1-era builds carrying revisions 49-52 pass the installer and then
land in this branch. Closing that needs the revision-to-build mapping, which is
not in the repo and which the vendor's API page would not serve.

## 3. Both READMEs

The **packaged** README told users to uninstall by deleting `mb_remote.dll`,
which leaves the native core and the helper behind - it has been two DLLs plus an
exe since the Rust rewrite. It also described `mbrc-helper.exe` as a firewall
utility; it is that *and* the thing that installs updates, so skipping it quietly
disables "Install and restart".

The **main** README could not be followed to a build: the prerequisites listed
Visual Studio, the .NET Framework SDK and MusicBee, and no Rust at all, while the
core and helper are Rust and must target `i686-pc-windows-msvc`. It also claimed
`build-msbuild.ps1` "builds only the C# solution", which is false - the plugin
project has an MSBuild target that invokes `build.ps1 -Rust`, which is also why
`dotnet build` and Visual Studio produce a complete set of binaries.

Releasing was stale in two ways that matter right now: the version stamp reaches
`mbrc_core.dll` as well as the helper and CI always sets `MBRC_VERSION`, and a
prerelease tag routes itself to the testing channel and a GitHub pre-release -
which is how a beta actually gets cut, so it is now documented. Plus
`mbrc-buildinfo` was missing from the project structure, `mdns-sd` from the
dependency list, and there was no pointer to `docs/` at all.

## Verified

Version ordering holds where it matters: `1.4.1.0 < 1.5.0-beta.1 <
1.5.0-beta.2 < 1.5.0 == 1.5.0.0`. Built at `/p:Version=1.5.0-beta.1` and confirmed
the suffix survives into the assembly. Build clean, `dotnet format` clean.

Also checked and fine as-is: NSIS (`VIProductVersion` is hardcoded numeric, the
version only appears in string keys and the output filename, so
`musicbee_remote_1.5.0-beta.1.exe` builds), `is_bare_filename` accepts
`1.5.0-beta.1` (it becomes a staging directory name), and the channel routing from
#164.
