### PR TITLE
fix: pre-beta pass over the FFI, networking and discovery seams

### DIFF
--- a/packages/mbrc-core/src/logging.rs
+++ b/packages/mbrc-core/src/logging.rs
@@ -69,13 +69,26 @@ impl RotatingWriter {
             max_bytes,
         });
         if written >= max_bytes {
-            w.rotate(&mut w.inner.lock().unwrap());
+            w.rotate(&mut w.lock());
         }
         Ok(w)
     }
 
+    /// The writer state, surviving a poisoned lock.
+    ///
+    /// A panic anywhere while this is held would otherwise poison it, and every
+    /// later log call - from every thread, including ones that only log because
+    /// something already went wrong - would panic in turn. The data behind it is
+    /// a file handle and a byte count; neither is left inconsistent by an
+    /// unwind, so taking it back is strictly better than cascading.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     fn write_line(&self, buf: &[u8]) -> io::Result<usize> {
-        let mut inner = self.inner.lock().unwrap();
+        let mut inner = self.lock();
         if let Some(file) = inner.file.as_mut() {
             file.write_all(buf)?;
             inner.written += buf.len() as u64;

--- a/packages/mbrc-core/src/server/mod.rs
+++ b/packages/mbrc-core/src/server/mod.rs
@@ -27,6 +27,10 @@ use crate::state::Core;
 /// the answer already there.
 const STARTUP_UPDATE_CHECK_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// How long the accept loop pauses after a failed `accept`, so a persistent
+/// failure cannot become a busy loop.
+const ACCEPT_ERROR_BACKOFF: std::time::Duration = std::time::Duration::from_millis(200);
+
 /// How long networking shutdown waits for the mDNS advertisement to withdraw.
 /// Long enough for the goodbye packets to leave, short enough that a wedged
 /// daemon cannot hold up MusicBee closing.
@@ -266,10 +270,10 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
     if core.config.storage_path.is_empty() {
         return;
     }
-    if !core.try_begin_reconcile() {
+    let Some(reconcile) = core.begin_reconcile() else {
         tracing::debug!("library reconcile already in progress; skipping");
         return;
-    }
+    };
 
     // Start/finish transitions. The host UI (settings cache line) always
     // refreshes; the `librarycovercachebuildstatus` broadcast to network clients
@@ -399,8 +403,12 @@ fn run_reconcile(core: &Core, scope: RebuildScope) {
     } else {
         "MusicBee Remote: Done. Library metadata refreshed.".to_string()
     });
+    // Before the finish notification, so a panel refreshing on that event sees
+    // a cache that is no longer building. (The previous explicit
+    // `end_reconcile()` ran after `notify(false)`, so the line could stay on
+    // "Rebuilding cache..." until the next unrelated refresh.)
+    drop(reconcile);
     notify(false);
-    core.end_reconcile();
 }
 
 /// Incremental album-cover refresh, run from the Scanner's nudge path (a
@@ -531,7 +539,14 @@ async fn accept_loop(listener: TcpListener, core: Arc<Core>) {
                     }
                 });
             }
-            Err(e) => tracing::warn!(error = %e, "accept failed"),
+            // Do not spin. A transient failure is worth retrying immediately in
+            // principle, but a persistent one - descriptor exhaustion, a wedged
+            // listener - would otherwise turn this into a busy loop pegging a core
+            // inside MusicBee and filling the log as fast as it can rotate.
+            Err(e) => {
+                tracing::warn!(error = %e, "accept failed");
+                tokio::time::sleep(ACCEPT_ERROR_BACKOFF).await;
+            }
         }
     }
 }

--- a/packages/mbrc-core/src/server/scanner.rs
+++ b/packages/mbrc-core/src/server/scanner.rs
@@ -79,10 +79,10 @@ async fn scan(core: &Arc<Core>, covers: bool) {
 
     let core = core.clone();
     let _ = tokio::task::spawn_blocking(move || {
-        if !core.try_begin_reconcile() {
+        let Some(reconcile) = core.begin_reconcile() else {
             tracing::debug!("scanner: reconcile in progress; skipping delta");
             return;
-        }
+        };
         // Tell the settings panel a scan is running (its cache-status line reads
         // `is_reconciling`), matching what a manual rebuild emits. Paired with the
         // finish event below so the line clears once the delta completes.
@@ -92,7 +92,11 @@ async fn scan(core: &Arc<Core>, covers: bool) {
         if covers {
             super::refresh_covers_delta(&core);
         }
-        core.end_reconcile();
+        // Released before the finish event, not after: the panel answers that
+        // event by re-reading `is_reconciling`, so telling it to look while the
+        // guard is still held would leave the line saying "Rebuilding cache..."
+        // until something else happened to refresh it.
+        drop(reconcile);
         core.providers
             .emit_event(HostEventType::CacheStatusChanged, &[]);
     })

--- a/packages/mbrc-core/src/state.rs
+++ b/packages/mbrc-core/src/state.rs
@@ -87,22 +87,38 @@ impl Core {
         self.conn_counter.fetch_add(1, Ordering::Relaxed)
     }
 
-    /// Acquire the single-flight reconcile right: `true` if the caller may run
-    /// `reconcile_library` (it must then call [`end_reconcile`](Self::end_reconcile)),
-    /// `false` if one is already in progress.
-    pub fn try_begin_reconcile(&self) -> bool {
-        !self.reconciling.swap(true, Ordering::AcqRel)
-    }
-
-    /// Release the reconcile right acquired by [`try_begin_reconcile`](Self::try_begin_reconcile).
-    pub fn end_reconcile(&self) {
-        self.reconciling.store(false, Ordering::Release);
+    /// Acquire the single-flight reconcile right, or `None` if one is already in
+    /// progress.
+    ///
+    /// A guard rather than a pair of calls, because the work it spans is long
+    /// (a library scan, blocking calls into MusicBee, and a thread pool doing
+    /// the cover build) and the cost of not releasing it is silent and
+    /// permanent: no further rebuild would run for the rest of the session, a
+    /// library switch would be ignored, and the settings panel would sit on
+    /// "Rebuilding cache..." forever. Dropping is the one thing that happens on
+    /// every path out, including a panic.
+    pub fn begin_reconcile(&self) -> Option<ReconcileGuard<'_>> {
+        if self.reconciling.swap(true, Ordering::AcqRel) {
+            None
+        } else {
+            Some(ReconcileGuard(self))
+        }
     }
 
     /// Whether a library reconcile / cache build is currently running. Surfaced
     /// to the settings panel's cache-status line.
     pub fn is_reconciling(&self) -> bool {
         self.reconciling.load(Ordering::Acquire)
+    }
+}
+
+/// Holds the single-flight reconcile right for as long as it is alive; see
+/// [`Core::begin_reconcile`].
+pub struct ReconcileGuard<'a>(&'a Core);
+
+impl Drop for ReconcileGuard<'_> {
+    fn drop(&mut self) {
+        self.0.reconciling.store(false, Ordering::Release);
     }
 }
 

--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -214,13 +214,20 @@ namespace MusicBeePlugin.Host
             _userSettings.Source = (SearchSource)s.search_source;
         }
 
-        /// <summary>Only a port or address-filter change needs the listener rebound.</summary>
+        /// <summary>
+        ///     Whether a settings change needs networking restarted: the port and
+        ///     the address filter, because they decide what the listener binds and
+        ///     admits, and mDNS, because the advertisement task is started (or not)
+        ///     when networking starts - without this, unticking the checkbox would
+        ///     appear to do nothing until MusicBee was restarted.
+        /// </summary>
         private static bool NeedsRestart(CoreSettings a, CoreSettings b)
         {
             return a.port != b.port
                    || a.filter_mode != b.filter_mode
                    || a.base_ip != b.base_ip
                    || a.last_octet_max != b.last_octet_max
+                   || a.mdns_enabled != b.mdns_enabled
                    || !ListEqual(a.allowed_addresses, b.allowed_addresses);
         }
 

--- a/packages/plugin/Plugin.cs
+++ b/packages/plugin/Plugin.cs
@@ -288,8 +288,20 @@ namespace MusicBeePlugin
         /// <param name="reason">The reason for closing.</param>
         public void Close(PluginCloseReason reason)
         {
-            _host?.Dispose();
-            _host = null;
+            // MusicBee calls this on its way out; an exception escaping here is a
+            // crash dialog on exit, after the user has already asked to leave.
+            try
+            {
+                _host?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("Plugin Close failed", ex);
+            }
+            finally
+            {
+                _host = null;
+            }
         }
 
         /// <summary>
@@ -375,7 +387,19 @@ namespace MusicBeePlugin
                     return;
             }
 
-            _host.HandleNotification((int)coreType);
+            // Guarded like every other MusicBee-facing entry point, and this is the
+            // busiest of them: it fires for every player event and every tag or
+            // library change. The FFI call itself is guarded inside the bridge, so
+            // this is the belt to that braces - a notification must never be able
+            // to throw back into MusicBee's event dispatch.
+            try
+            {
+                _host.HandleNotification((int)coreType);
+            }
+            catch (Exception ex)
+            {
+                LogToFallback("ReceiveNotification failed", ex);
+            }
         }
     }
 }


### PR DESCRIPTION
A review of the three places a beta could actually hurt someone: what could take MusicBee down with it, the networking layer, and discovery. Five findings, all fixed here.

## Could it crash MusicBee?

**Two entry points were unguarded.** Every other MusicBee-facing method wraps its body so an exception cannot escape into the host - `Close` and `ReceiveNotification` did not. `Close` runs as MusicBee exits, where a throw becomes a crash dialog *after* the user has already asked to leave. `ReceiveNotification` is the busiest callback in the plugin: every player event, every tag or library change. The FFI call inside it is guarded by the bridge, but the method around it was not. Both now log to `initialization_error.log` instead of throwing.

**The reconcile single-flight guard could leak.** `try_begin_reconcile` and `end_reconcile` sat 134 lines apart, spanning a library scan, blocking calls into MusicBee, and a scoped thread pool doing the cover build. A panic anywhere in between left the flag set for the rest of the session: no further rebuild would run, a library switch would be ignored, and the settings panel would sit on "Rebuilding cache..." with its buttons disabled. It is now an RAII guard - which immediately caught a third caller I had not spotted, the Scanner, which runs this every 60 seconds.

Converting it also fixed an ordering bug: the guard is released *before* the finish event, not after. The panel answers that event by re-reading `is_reconciling`, so the old order could leave the line reporting a rebuild that had already finished.

**The log lock panicked on poison.** `self.inner.lock().unwrap()`, where `state.rs` and `updates::service` both deliberately take a poisoned lock back. Behind that lock is a file handle and a byte count - neither left inconsistent by an unwind - whereas a poisoned log means every later log call panics, on every thread, including the ones that are only logging because something already went wrong.

## Networking

**The accept loop could hot-spin.** It correctly does not break out on a failed `accept`, but it also did not pause, so a persistent failure (descriptor exhaustion, a wedged listener) would busy-loop pegging a core inside MusicBee and filling the log as fast as it can rotate. 200ms backoff on the error arm.

Checked and found sound: per-connection panics unwind into their task and the `IpSlotGuard` still returns the per-IP slot; the frame accumulator's max-frame cap from #138 is in place; TCP keepalive is set per socket; a bind failure is reported synchronously and leaves the core initialised.

## Discovery

**The mDNS toggle did nothing until a restart** - a bug I introduced with the feature. The advertisement task is started when networking starts, and `NeedsRestart` did not include `mdns_enabled`, so unticking the box and saving looked like it worked and changed nothing. It now reloads exactly like a port change.

Tracing that same path answered the related question: saving a **new port** does re-advertise correctly. `StopNetworking` is synchronous and joins the networking thread, which is what waits for the goodbye packets, so the old record is withdrawn before the new SRV is registered rather than the two racing. The cost is that a port-change Save blocks the dialog for the ~500ms goodbye grace.

## Verified

Workspace tests (180 in the core) and clippy green; C# builds clean, `dotnet format` clean, 61 xUnit tests pass.