### PR TITLE
fix(plugin): refresh the reachable-at row after a port change

### DIFF
--- a/packages/plugin/Host/PluginHost.cs
+++ b/packages/plugin/Host/PluginHost.cs
@@ -167,9 +167,13 @@ namespace MusicBeePlugin.Host
         ///     does only the work each change needs: debug logging live, the
         ///     firewall rule host-side, and a listener reload only when the port or
         ///     address filter changed. Returns false if the core rejected them.
+        ///     <paramref name="reloaded" /> reports whether the listener was rebound,
+        ///     so the caller knows the rows describing it (reachable addresses, the
+        ///     connection test) now describe a different socket.
         /// </summary>
-        public bool ApplySettings(CoreSettings updated)
+        public bool ApplySettings(CoreSettings updated, out bool reloaded)
         {
+            reloaded = false;
             if (updated == null) return false;
 
             var current = _bridge.ReadSettings() ?? new CoreSettings();
@@ -189,7 +193,10 @@ namespace MusicBeePlugin.Host
 
             // Only a port or address-filter change needs the listener rebound.
             if (NeedsRestart(current, updated))
+            {
                 _bridge.Reload();
+                reloaded = true;
+            }
 
             return true;
         }

--- a/packages/plugin/Settings/SettingsDialog.cs
+++ b/packages/plugin/Settings/SettingsDialog.cs
@@ -658,10 +658,20 @@ namespace MusicBeePlugin.Settings
         /// <summary>Persist the edited settings to the core.</summary>
         private void Apply()
         {
-            var ok = _host.ApplySettings(Collect());
+            var ok = _host.ApplySettings(Collect(), out var reloaded);
             SetStatus(
                 ok ? "Settings saved." : "Settings were rejected - check the port and range values.",
                 ok);
+
+            // A save that rebound the listener (a new port, a changed filter) makes
+            // the two rows describing it stale: both were rendered from the socket
+            // that no longer exists. The reload finishes inside ApplySettings, so by
+            // here the core reports the new port and is already listening on it.
+            if (ok && reloaded)
+            {
+                LoadListeningAddresses();
+                RunConnectionTest();
+            }
         }
 
         private void LoadFromCore()
@@ -685,7 +695,9 @@ namespace MusicBeePlugin.Settings
         ///     Render the addresses a client can reach this server on (each
         ///     interface IPv4 + the bound port), read from the core. Shown so the
         ///     user knows what to enter in the phone app. The list reflects the
-        ///     running server, so it does not change while the dialog is open.
+        ///     running server, so it is re-read on load and after a save that
+        ///     rebinds the listener - nothing else changes it while the dialog is
+        ///     open.
         /// </summary>
         private void LoadListeningAddresses()
         {


### PR DESCRIPTION
## The bug

Saving a new port left the **Reachable at** row listing `ip:oldPort` until the
dialog was closed and reopened.

`LoadListeningAddresses()` and `RunConnectionTest()` are called only from the
`SettingsDialog` constructor, and `Apply()` saved the settings without re-running
either. The connection-test line went stale the same way, but self-corrected
because the "Test connection" button re-reads the live port.

## The fix

`PluginHost.ApplySettings` now reports whether it rebound the listener
(`out bool reloaded`, set on the existing `NeedsRestart` branch), and `Apply()`
re-runs both loads when it did.

Gated on the reload rather than refreshing on every save: a log-level or
search-source change does not touch the socket, and refreshing regardless would
cost an interface enumeration plus a loopback probe for nothing. The `out`
parameter is the only reason `PluginHost` changed at all - the dialog cannot
otherwise tell a rebinding save from an ordinary one, and `ApplySettings` has
exactly one caller.

## Why reading straight after the save is safe

Verified rather than assumed:

- `NativeBridge.Reload()` is stop -> `mbrc_shutdown` -> `Initialize` (which
  re-reads `core_settings.json`) -> `StartNetworking`, all synchronous.
- `server::start` (`packages/mbrc-core/src/server/mod.rs:60`) blocks on a ready
  channel until `TcpListener::bind` succeeds.

So by the time `Apply()` continues, `listening_info_bytes` reports the new
`core.config.port` and the probe hits a socket that is actually listening.

## Coverage

The panel renders the server port in three places, and all three are now
consistent after a save: the "Listening port" spinner (the edit itself), the
"Reachable at" list, and the connection-test line. The port in
`BlockedConnectionsDialog` is the remote peer's source port on a rejected
connection, not the listening port, and that list polls on a timer.

## Notes

- A port-change save costs ~500ms for the mDNS goodbye grace. That happens
  inside `ApplySettings` on the UI thread, so the dialog is already frozen
  through it and the refresh lands after; `RunConnectionTest` shows "Testing..."
  on its own while the probe runs off-thread. No extra transient state needed.
- Also corrected the now-wrong doc comment on `LoadListeningAddresses` ("does
  not change while the dialog is open").

## Testing

- `build.ps1 -Plugin` clean (the remaining warnings are pre-existing).
- 61 C# tests pass.
- **Not covered by tests:** `SettingsDialog` is WinForms-constructed and has no
  test coverage, so the port-change behaviour itself is unverified until it is
  exercised live. Worth a click during the beta.1 install.
